### PR TITLE
refactor(customerRepository): Create interface CustomerRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ out/
 !**/src/test/**/out/
 *.iml
 .idea/
-.target/
+target/
 
 ### Eclipse ###
 .apt_generated

--- a/src/main/java/com/sistema/adaptadores/api/CriarClienteResource.java
+++ b/src/main/java/com/sistema/adaptadores/api/CriarClienteResource.java
@@ -5,10 +5,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sistema.casodeuso.CriarClienteUseCase;
 import com.sistema.dominio.entidade.Cliente;
 import com.sistema.adaptadores.dto.ClienteDTO;
-import com.sistema.infraestrutura.entidade.ClienteEntity;
 import com.sistema.infraestrutura.mapper.ClienteMapper;
 
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -28,12 +27,12 @@ public class CriarClienteResource {
     ClienteMapper clienteMapper;
 
     @Inject
-    ClienteRepository clienteRepository;
+    CustomerRepository customerRepository;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAllClientes(){
-        List<ClienteEntity> clientes = clienteRepository.findAllAsList();
+        List<Cliente> clientes = customerRepository.findAllAsList();
 
         if(clientes.isEmpty()){
             return Response.status(Response.Status.NO_CONTENT).build();

--- a/src/main/java/com/sistema/adaptadores/api/FaturaResource.java
+++ b/src/main/java/com/sistema/adaptadores/api/FaturaResource.java
@@ -6,9 +6,8 @@ import com.sistema.adaptadores.dto.TransacaoDTO;
 import com.sistema.casodeuso.RegistarTransacaoNaFaturaUseCase;
 import com.sistema.dominio.entidade.Fatura;
 import com.sistema.dominio.entidade.Transacao;
-import com.sistema.infraestrutura.entidade.FaturaEntity;
 import com.sistema.infraestrutura.mapper.TransacaoMapper;
-import com.sistema.infraestrutura.repositorio.FaturaRepository;
+import com.sistema.dominio.repository.FaturaRepository;
 import com.sistema.infraestrutura.repositorio.TransacaoRepository;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -18,7 +17,6 @@ import jakarta.ws.rs.core.Response;
 
 import java.time.LocalDate;
 import java.util.Optional;
-
 
 @Path("/fatura")
 @Produces(MediaType.APPLICATION_JSON)
@@ -41,7 +39,7 @@ public class FaturaResource {
     @Path("/{ano}/{mes}")
     public Response getFatura(@PathParam("ano") int ano, @PathParam("mes") int mes){
         LocalDate mesAno = LocalDate.of(ano, mes, 1);
-        Optional<FaturaEntity> faturaOpt = faturaRepository.findByMesAno(mesAno);
+        Optional<Fatura> faturaOpt = faturaRepository.findByMesAno(mesAno);
         return faturaOpt.map(Response::ok).orElse(Response.status(Response.Status.NOT_FOUND)).build();
     }
 
@@ -73,13 +71,13 @@ public class FaturaResource {
     public Response pagarFatura(@PathParam("ano") int ano, @PathParam("mes") int mes) {
 
         LocalDate mesAno = LocalDate.of(ano, mes, 1);
-        Optional<FaturaEntity> faturaOpt = faturaRepository.findByMesAno(mesAno);
+        Optional<Fatura> faturaOpt = faturaRepository.findByMesAno(mesAno);
 
         if (faturaOpt.isEmpty()) {
             return Response.status(Response.Status.NOT_FOUND).entity("Fatura não encontrada").build();
         }
 
-        FaturaEntity fatura = faturaOpt.get();
+        Fatura fatura = faturaOpt.get();
         fatura.setPaga(true);
         return Response.ok().entity("Fatura paga com Sucesso!").build();
     }

--- a/src/main/java/com/sistema/casodeuso/CriarCartaoUseCase.java
+++ b/src/main/java/com/sistema/casodeuso/CriarCartaoUseCase.java
@@ -9,7 +9,7 @@ import com.sistema.infraestrutura.mapper.CartaoDeCreditoMapper;
 import com.sistema.infraestrutura.mapper.ClienteMapper;
 import com.sistema.infraestrutura.repositorio.CartaoDeCreditoRepository;
 
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -28,7 +28,7 @@ public class CriarCartaoUseCase {
     CartaoDeCreditoRepository cartaoDeCreditoRepository;
 
     @Inject
-    ClienteRepository clienteRepository;
+    CustomerRepository customerRepository;
 
     @Inject
     ClienteMapper clienteMapper;
@@ -41,15 +41,13 @@ public class CriarCartaoUseCase {
 
         System.out.println("Recebido DTO bandeira: " + cartaoDTO.getBandeira());
 
-        ClienteEntity clienteEntity = clienteRepository.findById((UUID.fromString(cartaoDTO.getClienteId())));
+        Cliente cliente = customerRepository.findById((UUID.fromString(cartaoDTO.getClienteId())));
 
-        if (clienteEntity == null) {
+        if (cliente == null) {
 
             throw new IllegalArgumentException("Cliente não Encontrado:" + cartaoDTO.getClienteId());
 
         }
-
-        Cliente cliente = clienteMapper.toDomain(clienteEntity);
 
         System.out.println("Recebido clienteMapper bandeira: " + cliente.getNome());
 

--- a/src/main/java/com/sistema/casodeuso/CriarCartaoUseCase.java
+++ b/src/main/java/com/sistema/casodeuso/CriarCartaoUseCase.java
@@ -4,10 +4,9 @@ import com.sistema.adaptadores.dto.CartaoDeCreditoDTO;
 import com.sistema.dominio.entidade.CartaoDeCredito;
 import com.sistema.dominio.entidade.Cliente;
 import com.sistema.dominio.servico.CartaoDeCreditoService;
-import com.sistema.infraestrutura.entidade.ClienteEntity;
 import com.sistema.infraestrutura.mapper.CartaoDeCreditoMapper;
 import com.sistema.infraestrutura.mapper.ClienteMapper;
-import com.sistema.infraestrutura.repositorio.CartaoDeCreditoRepository;
+import com.sistema.dominio.repository.CartaoRepository;
 
 import com.sistema.dominio.repository.CustomerRepository;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -25,7 +24,7 @@ public class CriarCartaoUseCase {
     CartaoDeCreditoService cartaoDeCreditoService;
 
     @Inject
-    CartaoDeCreditoRepository cartaoDeCreditoRepository;
+    CartaoRepository cartaoDeCreditoRepository;
 
     @Inject
     CustomerRepository customerRepository;
@@ -44,14 +43,10 @@ public class CriarCartaoUseCase {
         Cliente cliente = customerRepository.findById((UUID.fromString(cartaoDTO.getClienteId())));
 
         if (cliente == null) {
-
             throw new IllegalArgumentException("Cliente não Encontrado:" + cartaoDTO.getClienteId());
-
         }
 
-        System.out.println("Recebido clienteMapper bandeira: " + cliente.getNome());
-
-        CartaoDeCredito cartaoCriado = cartaoDeCreditoService.criarCartao(
+            CartaoDeCredito cartaoCriado = cartaoDeCreditoService.criarCartao(
                 cartaoDTO.getBandeira(),
                 cartaoDTO.getNomeTitular(),
                 LocalDate.now().plusYears(5),
@@ -63,15 +58,6 @@ public class CriarCartaoUseCase {
 
         System.out.println("Recebido cartaoCriado bandeira: " + cartaoCriado.getBandeira());
 
-        var entity = cartaoDeCreditoMapper.toEntity(cartaoCriado);
-
-       System.out.println("Recebido bandeira Entity: " + entity.getBandeira());
-
-        cartaoDeCreditoRepository.persist(entity);
-
-        //System.out.println("ID Cartão Gerado: " + entity.getId()); // Verifica se o ID foi gerado
-       // System.out.println("ID Cliente: " + entity.getCliente().getId());
-        return cartaoDeCreditoMapper.toDomain(entity);
-
+        return cartaoDeCreditoRepository.save(cartaoCriado);
     }
 }

--- a/src/main/java/com/sistema/casodeuso/CriarClienteUseCase.java
+++ b/src/main/java/com/sistema/casodeuso/CriarClienteUseCase.java
@@ -2,7 +2,7 @@ package com.sistema.casodeuso;
 
 import com.sistema.dominio.entidade.Cliente;
 import com.sistema.infraestrutura.entidade.ClienteEntity;
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import com.sistema.infraestrutura.mapper.ClienteMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
@@ -12,22 +12,18 @@ import java.util.UUID;
 @ApplicationScoped
 public class CriarClienteUseCase {
 
-    private final ClienteRepository clienteRepository;
-    private final ClienteMapper clienteMapper;
+    private final CustomerRepository customerRepository;
 
-    public CriarClienteUseCase(ClienteRepository clienteRepository, ClienteMapper clienteMapper) {
-        this.clienteRepository = clienteRepository;
-        this.clienteMapper = clienteMapper;
+    public CriarClienteUseCase(CustomerRepository customerRepository) {
+        this.customerRepository = customerRepository;
     }
 
     @Transactional
     public Cliente executar (Cliente cliente){
-        var clienteEntity = clienteMapper.toEntity(cliente);
-        clienteRepository.persist(clienteEntity);
-        return clienteMapper.toDomain(clienteEntity);
+        return customerRepository.save(cliente);
     }
 
-    public ClienteEntity findById (UUID id){
-        return clienteRepository.findById(id);
+    public Cliente findById (UUID id){
+        return customerRepository.findById(id);
     }
 }

--- a/src/main/java/com/sistema/casodeuso/RegistarCompraCasoDeUso.java
+++ b/src/main/java/com/sistema/casodeuso/RegistarCompraCasoDeUso.java
@@ -1,11 +1,10 @@
 package com.sistema.casodeuso;
 
+import com.sistema.dominio.entidade.CartaoDeCredito;
 import com.sistema.dominio.entidade.Transacao;
-import com.sistema.infraestrutura.entidade.CartaoDeCreditoEntity;
 import com.sistema.infraestrutura.entidade.TransacaoEntity;
-import com.sistema.infraestrutura.mapper.CartaoDeCreditoMapper;
 import com.sistema.infraestrutura.mapper.TransacaoMapper;
-import com.sistema.infraestrutura.repositorio.CartaoDeCreditoRepository;
+import com.sistema.dominio.repository.CartaoRepository;
 import com.sistema.infraestrutura.repositorio.TransacaoRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -15,7 +14,7 @@ import jakarta.transaction.Transactional;
 public class RegistarCompraCasoDeUso {
 
     @Inject
-    CartaoDeCreditoRepository cartaoDeCreditoRepository;
+    CartaoRepository cartaoDeCreditoRepository;
 
     @Inject
     TransacaoRepository transacaoRepository;
@@ -23,23 +22,20 @@ public class RegistarCompraCasoDeUso {
     @Inject
     TransacaoMapper transacaoMapper;
 
-    @Inject
-    CartaoDeCreditoMapper cartaoDeCreditoMapper;
-
     @Transactional
     public Transacao registraCompra(Transacao transacao) {
 
-        CartaoDeCreditoEntity cartaoEntity = cartaoDeCreditoRepository.findById(transacao.getCartao().getId());
-        if (cartaoEntity == null){
+        CartaoDeCredito cartao = cartaoDeCreditoRepository.findById(transacao.getCartao().getId());
+        if (cartao == null){
             throw new IllegalArgumentException("Cartão não encontrado");
         }
 
-        if (cartaoEntity.getLimiteDisponivel().compareTo(transacao.getValor()) < 0){
+        if (cartao.getLimiteDisponivel().compareTo(transacao.getValor()) < 0){
             throw new IllegalArgumentException(("Limite Insuficiente para essa compra!"));
         }
 
-        System.out.println("TESTE###########: " + cartaoEntity.getCliente().getDataCadastro());
-        transacao.setCartao(cartaoDeCreditoMapper.toDomain(cartaoEntity));
+        System.out.println("TESTE###########: " + cartao.getCliente().getDataCadastro());
+        transacao.setCartao(cartao);
 
         TransacaoEntity transacaoEntity = transacaoMapper.toEntity(transacao);
         transacaoRepository.persist(transacaoEntity);

--- a/src/main/java/com/sistema/dominio/repository/CartaoRepository.java
+++ b/src/main/java/com/sistema/dominio/repository/CartaoRepository.java
@@ -1,8 +1,12 @@
 package com.sistema.dominio.repository;
 
 import com.sistema.dominio.entidade.CartaoDeCredito;
+import com.sistema.infraestrutura.entidade.CartaoDeCreditoEntity;
+
+import java.util.UUID;
 
 public interface CartaoRepository {
 
     CartaoDeCredito save(CartaoDeCredito cartaoDeCredito);
+    CartaoDeCredito findById(UUID id);
 }

--- a/src/main/java/com/sistema/dominio/repository/CustomerRepository.java
+++ b/src/main/java/com/sistema/dominio/repository/CustomerRepository.java
@@ -1,0 +1,12 @@
+package com.sistema.dominio.repository;
+
+import com.sistema.dominio.entidade.Cliente;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CustomerRepository {
+    Cliente save(Cliente cliente);
+    List<Cliente> findAllAsList();
+    Cliente findById(UUID id);
+}

--- a/src/main/java/com/sistema/dominio/servico/ClienteService.java
+++ b/src/main/java/com/sistema/dominio/servico/ClienteService.java
@@ -1,9 +1,7 @@
 package com.sistema.dominio.servico;
 
 import com.sistema.dominio.entidade.Cliente;
-import com.sistema.infraestrutura.entidade.ClienteEntity;
-import com.sistema.infraestrutura.mapper.ClienteMapper;
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import java.util.UUID;
@@ -11,24 +9,19 @@ import java.util.UUID;
 @ApplicationScoped
 public class ClienteService {
 
-    private final ClienteRepository clienteRepository;
-    private final ClienteMapper clienteMapper;
+    private final CustomerRepository customerRepository;
 
-    public ClienteService(ClienteRepository clienteRepository, ClienteMapper clienteMapper) {
-        this.clienteRepository = clienteRepository;
-        this.clienteMapper = clienteMapper;
+    public ClienteService(CustomerRepository customerRepository) {
+        this.customerRepository = customerRepository;
     }
 
     @Transactional
     public void salvarCliente(Cliente cliente){
-
-        ClienteEntity entity = clienteMapper.toEntity(cliente);
-        clienteRepository.persist(entity);
+        customerRepository.save(cliente);
     }
 
     public Cliente buscarCliente (UUID id) {
-        ClienteEntity entity = clienteRepository.findById(id);
-        return clienteMapper.toDomain(entity);
+        return customerRepository.findById(id);
 
     }
 

--- a/src/main/java/com/sistema/infraestrutura/repositorio/CartaoDeCreditoRepositoryAdapter.java
+++ b/src/main/java/com/sistema/infraestrutura/repositorio/CartaoDeCreditoRepositoryAdapter.java
@@ -8,7 +8,7 @@ import com.sistema.dominio.repository.CartaoRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-
+import java.util.UUID;
 
 @ApplicationScoped
 public class CartaoDeCreditoRepositoryAdapter implements CartaoRepository, PanacheRepository<CartaoDeCreditoEntity> {
@@ -20,6 +20,11 @@ public class CartaoDeCreditoRepositoryAdapter implements CartaoRepository, Panac
         CartaoDeCreditoEntity entity = cartaoMapper.toEntity(cartao);
         persist(entity);
         getEntityManager().flush();
+        return cartaoMapper.toDomain(entity);
+    }
+
+    public CartaoDeCredito findById(UUID id) {
+        CartaoDeCreditoEntity entity = find("id", id).firstResult();
         return cartaoMapper.toDomain(entity);
     }
 }

--- a/src/main/java/com/sistema/infraestrutura/repositorio/CustomerRepositoryAdapter.java
+++ b/src/main/java/com/sistema/infraestrutura/repositorio/CustomerRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.sistema.infraestrutura.repositorio;
+
+import com.sistema.dominio.entidade.Cliente;
+import com.sistema.dominio.repository.CustomerRepository;
+import com.sistema.infraestrutura.entidade.ClienteEntity;
+import com.sistema.infraestrutura.mapper.ClienteMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class CustomerRepositoryAdapter implements CustomerRepository, PanacheRepository<ClienteEntity> {
+
+    @Inject
+    ClienteMapper clienteMapper;
+
+    @Override
+    public Cliente save(Cliente cliente) {
+        ClienteEntity entity = clienteMapper.toEntity(cliente);
+        persist(entity);
+        return clienteMapper.toDomain(entity);
+    }
+
+    @Override
+    public List<Cliente> findAllAsList() {
+        List<ClienteEntity> entities = list("ORDER BY nome ASC");
+        return entities.stream()
+                .map(clienteMapper::toDomain)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Cliente findById(UUID id) {
+        ClienteEntity entity = find("id", id).firstResult();
+        return clienteMapper.toDomain(entity);
+    }
+}

--- a/src/test/java/com/sistema/casodeuso/CriarCartaoUseCaseTest.java
+++ b/src/test/java/com/sistema/casodeuso/CriarCartaoUseCaseTest.java
@@ -8,7 +8,7 @@ import com.sistema.infraestrutura.entidade.CartaoDeCreditoEntity;
 import com.sistema.infraestrutura.entidade.ClienteEntity;
 import com.sistema.infraestrutura.mapper.CartaoDeCreditoMapper;
 import com.sistema.infraestrutura.repositorio.CartaoDeCreditoRepository;
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import com.sistema.infraestrutura.mapper.ClienteMapper;
 
 import io.quarkus.test.InjectMock;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 public class CriarCartaoUseCaseTest {
 
     @InjectMock
-    ClienteRepository clienteRepository;
+    CustomerRepository customerRepository;
 
     @InjectMock
     CartaoDeCreditoRepository cartaoDeCreditoRepository;
@@ -50,17 +50,11 @@ public class CriarCartaoUseCaseTest {
     @Test
     public void testCriarCartaoDeCreditoValidocomCliente(){
 
-        //mock um clienteEntity
+        //mock Cliente
         UUID clienteId = UUID.randomUUID();
-        ClienteEntity clienteEntity = new ClienteEntity();
-        clienteEntity.setId(clienteId);
-        clienteEntity.setNome("João Silva");
-        when(clienteRepository.findById(clienteId)).thenReturn(clienteEntity);
-
-        // Mock do ClienteMapper para converter ClienteEntity para Cliente (domínio)
         Cliente cliente = new Cliente("João Silva", "1234567890");
         cliente.setId(clienteId);
-        when(clienteMapper.toDomain(clienteEntity)).thenReturn(cliente);
+        when(customerRepository.findById(clienteId)).thenReturn(cliente);
 
         //mock cartao de credito
         UUID cartaoId = UUID.randomUUID();
@@ -118,8 +112,7 @@ public class CriarCartaoUseCaseTest {
 
         //verificar se criou o cartao de credito da forma esperada
         assertNotNull(cartaoAValidar);
-        verify(clienteRepository, times(1)).findById(clienteId);
-        verify(clienteMapper, times(1)).toDomain(clienteEntity);
+        verify(customerRepository, times(1)).findById(clienteId);
         verify(cartaoDeCreditoRepository, times(1)).persist(cartaoEntity);
         
     }

--- a/src/test/java/com/sistema/util/CartaoDeCreditoBuilder.java
+++ b/src/test/java/com/sistema/util/CartaoDeCreditoBuilder.java
@@ -4,9 +4,7 @@ import com.sistema.dominio.entidade.CartaoDeCredito;
 import com.sistema.dominio.entidade.Cliente;
 import com.sistema.dominio.servico.CartaoDeCreditoService;
 import com.sistema.dominio.servico.GeradorNumeroCartao;
-import com.sistema.infraestrutura.entidade.ClienteEntity;
-import com.sistema.infraestrutura.mapper.ClienteMapper;
-import com.sistema.infraestrutura.repositorio.ClienteRepository;
+import com.sistema.dominio.repository.CustomerRepository;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -23,10 +21,7 @@ public class CartaoDeCreditoBuilder {
     private UUID cartaoId;
 
     @Inject
-    private ClienteMapper clienteMapper;
-
-    @Inject
-    private ClienteRepository clienteRepository;
+    private CustomerRepository customerRepository;
 
     public CartaoDeCreditoBuilder comID(UUID cartaoId){
         this.cartaoId = cartaoId;
@@ -47,10 +42,7 @@ public class CartaoDeCreditoBuilder {
     public CartaoDeCredito build() {
 
         if (persistirCliente && cliente != null) {
-            ClienteEntity entity = clienteMapper.toEntity(cliente);
-            clienteRepository.persist(entity);
-          //  clienteRepository.getEntityManager().flush();
-            this.cliente = clienteMapper.toDomain(entity);
+            this.cliente = customerRepository.save(cliente);
         }
 
         CartaoDeCreditoService cartaoDeCreditoService = new CartaoDeCreditoService(new GeradorNumeroCartao());


### PR DESCRIPTION
Change the ClienteRepository implementation to an interface called CustomerRepository and its implementation to CustomerRepositoryAdapter to avoid 'mapper hell',  which was perceived in the code, and to isolate the domain as well.