### PR TITLE
wallet-module-initial-implementation

### DIFF
--- a/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
+++ b/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
@@ -1,0 +1,316 @@
+# Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)
+
+> Objetivo: transformar o Ledger Core já existente em um **produto utilizável via API**, através de um módulo de **Wallet**, permitindo que plataformas criem contas para seus usuários, movimentem saldo entre eles e consultem saldo/extrato de forma segura e multi-tenant.
+
+O Ledger continua sendo o **motor contábil interno**. A Wallet API é a **camada de produto** exposta a clientes externos.
+
+---
+
+## 1. Proposta de Valor do MVP
+
+Este MVP permite que uma plataforma terceira tenha:
+
+- Contas virtuais para seus usuários finais
+- Transferências internas entre usuários
+- Saldo confiável e auditável
+- Extrato de movimentações
+
+Sem precisar construir um motor contábil próprio.
+
+Produto posicionável como:
+
+> **Wallet / Ledger API para plataformas digitais**
+
+---
+
+## 2. Escopo da Fase 1
+
+### Em escopo
+
+- Módulo **Wallet** como camada sobre o Ledger
+- API para criação de contas de usuários (WalletAccounts)
+- API de consulta de saldo (derivado do Ledger)
+- API de extrato (derivado do Ledger)
+- API de transferência entre contas
+- Idempotência em transferências
+- Multi-tenant via API Key
+
+### Fora de escopo
+
+- Cartão de crédito
+- Juros e taxas
+- Integração bancária real
+- Split entre múltiplas partes
+- Webhooks
+
+---
+
+## 3. Arquitetura Lógica
+
+```
+Cliente da API
+       │
+       ▼
+   Wallet API  (produto)
+       │
+       ▼
+   Ledger Core (motor contábil)
+```
+
+- A Wallet **nunca altera saldo diretamente**.
+- Toda movimentação financeira é feita via **LedgerTransaction**.
+
+---
+
+## 4. Conceitos Principais
+
+### 4.1 LedgerAccount
+
+Conta contábil real do núcleo do ledger que participa de lançamentos (entries) e cálculo de saldo.
+
+Características:
+
+- Pertence a um `tenantId`
+- Possui `currency`, `type`, `allowNegative`
+- Não conhece usuário, produto ou wallet
+
+---
+
+### 4.2 WalletAccount (novo — camada de produto)
+
+Representa a conta exposta ao cliente da API.
+
+Ela é um **espelho funcional** de uma `LedgerAccount`.
+
+Campos principais:
+
+- `accountId` (UUID da Wallet)
+- `tenantId`
+- `ownerType` (ex: CUSTOMER)
+- `ownerId` (ID do usuário no sistema do cliente)
+- `currency`
+- `status`
+- `label` (opcional)
+- `ledgerAccountId` (FK lógica para LedgerAccount)
+
+**Regra:** WalletAccount não armazena saldo. Saldo e extrato são sempre consultados no Ledger.
+
+Restrição inicial:
+
+> 1 WalletAccount principal por (tenantId, ownerType, ownerId, currency)
+
+---
+
+### 4.3 Transferência
+
+Movimentação de saldo entre duas WalletAccounts do mesmo tenant.
+
+A Wallet traduz a operação para o Ledger como:
+
+- DEBIT na LedgerAccount de origem
+- CREDIT na LedgerAccount de destino
+
+---
+
+### 4.4 Resolução de Tenant
+
+Cada requisição deve conter:
+
+```
+X-API-Key: <apiKey>
+```
+
+Fluxo:
+
+1. API Key → resolve `tenantId`
+2. `tenantId` é propagado para todos os use cases do Ledger
+3. É proibida qualquer operação entre tenants diferentes
+
+---
+
+## 5. Requisitos Funcionais
+
+### RF-01 — Criar Conta (WalletAccount)
+
+**POST /accounts**
+
+Headers:
+
+- `X-API-Key: <apiKey>`
+
+Request:
+
+```json
+{
+  "ownerType": "CUSTOMER",
+  "ownerId": "user-123",
+  "currency": "BRL",
+  "label": "Main Wallet"
+}
+```
+
+Processo:
+
+1. Resolver `tenantId`
+2. Validar unicidade (tenantId, ownerType, ownerId, currency)
+3. Criar LedgerAccount correspondente (ex: LIABILITY, allowNegative=false)
+4. Criar WalletAccount vinculando `ledgerAccountId`
+
+Response:
+
+```json
+{
+  "accountId": "wallet-account-uuid",
+  "ownerType": "CUSTOMER",
+  "ownerId": "user-123",
+  "currency": "BRL",
+  "status": "ACTIVE"
+}
+```
+
+---
+
+### RF-02 — Consultar Saldo
+
+**GET /accounts/{accountId}/balance**
+
+Processo:
+
+- Resolver `tenantId`
+- Buscar WalletAccount → obter `ledgerAccountId`
+- Chamar Ledger: `GetBalance(tenantId, ledgerAccountId)`
+
+Response:
+
+```json
+{
+  "accountId": "wallet-account-uuid",
+  "balanceMinor": 100000,
+  "currency": "BRL"
+}
+```
+
+---
+
+### RF-03 — Extrato da Conta
+
+**GET /accounts/{accountId}/statement**
+
+Processo:
+
+- Resolver `tenantId`
+- Buscar WalletAccount → `ledgerAccountId`
+- Consultar Ledger por entries da conta
+
+Response:
+
+```json
+{
+  "accountId": "wallet-account-uuid",
+  "items": [
+    {
+      "transactionId": "uuid",
+      "occurredAt": "...",
+      "description": "Transfer",
+      "direction": "DEBIT",
+      "amountMinor": 5000,
+      "currency": "BRL"
+    }
+  ]
+}
+```
+
+---
+
+### RF-04 — Transferência entre Contas
+
+**POST /transfers**
+
+Headers:
+
+- `X-API-Key: <apiKey>`
+
+Request:
+
+```json
+{
+  "idempotencyKey": "txn-123",
+  "fromAccountId": "wallet-account-uuid",
+  "toAccountId": "wallet-account-uuid",
+  "amountMinor": 5000,
+  "currency": "BRL",
+  "description": "User transfer"
+}
+```
+
+Processo:
+
+1. Resolver `tenantId`
+2. Buscar WalletAccounts (origem e destino)
+3. Validar saldo suficiente na origem
+4. Chamar Ledger para criar LedgerTransaction (2 entries)
+
+Resposta:
+
+```json
+{
+  "transactionId": "uuid",
+  "status": "POSTED"
+}
+```
+
+---
+
+## 6. Segurança
+
+- Autenticação via API Key
+- Todas as operações isoladas por `tenantId`
+- Proibido acesso a contas de outro tenant
+
+---
+
+## 7. Requisitos Não Funcionais
+
+- Operações financeiras atômicas
+- Ledger permanece imutável
+- Logs com tenantId + idempotencyKey
+- Rate limit por API Key
+
+---
+
+## 8. Estrutura Técnica Esperada
+
+Novos módulos:
+
+```
+/wallet/api
+/wallet/application
+/wallet/domain
+```
+
+Reutilizando:
+
+```
+/ledger
+```
+
+---
+
+## 9. Entregáveis da Fase 1
+
+- Entidade WalletAccount
+- Integração Wallet → LedgerAccount
+- Endpoints REST de accounts e transfers
+- Use case TransferBetweenAccounts
+- Testes de integração multi-tenant
+
+---
+
+## 10. Resultado Esperado
+
+Ao final da Fase 1 será possível demonstrar:
+
+> “Criar contas de usuários, movimentar saldo entre eles e consultar extratos via API multi-tenant.”
+
+Base pronta para monetização como **Wallet / Ledger API**.
+

--- a/src/main/java/com/sistema/ledger/infra/entity/TenantEntity.java
+++ b/src/main/java/com/sistema/ledger/infra/entity/TenantEntity.java
@@ -1,0 +1,57 @@
+package com.sistema.ledger.infra.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenants")
+public class TenantEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/WalletAccountResource.java
+++ b/src/main/java/com/sistema/wallet/api/WalletAccountResource.java
@@ -1,0 +1,143 @@
+package com.sistema.wallet.api;
+
+import com.sistema.wallet.api.dto.CreateWalletAccountRequest;
+import com.sistema.wallet.api.dto.CreateWalletAccountResponse;
+import com.sistema.wallet.api.dto.WalletBalanceResponse;
+import com.sistema.wallet.api.dto.WalletStatementItemResponse;
+import com.sistema.wallet.api.dto.WalletStatementResponse;
+import com.sistema.wallet.application.CreateWalletAccountUseCase;
+import com.sistema.wallet.application.GetWalletBalanceUseCase;
+import com.sistema.wallet.application.GetWalletStatementUseCase;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.application.model.WalletStatementPage;
+import com.sistema.wallet.application.tenant.TenantResolver;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Path("/accounts")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class WalletAccountResource {
+    @Inject
+    TenantResolver tenantResolver;
+
+    @Inject
+    CreateWalletAccountUseCase createWalletAccountUseCase;
+
+    @Inject
+    GetWalletBalanceUseCase getWalletBalanceUseCase;
+
+    @Inject
+    GetWalletStatementUseCase getWalletStatementUseCase;
+
+    @POST
+    public Response createAccount(@HeaderParam("X-API-Key") String apiKey, CreateWalletAccountRequest request) {
+        UUID tenantId = requireTenantId(apiKey);
+        try {
+            WalletOwnerType ownerType = WalletOwnerType.valueOf(request.getOwnerType());
+            var command = new CreateWalletAccountCommand(
+                    ownerType,
+                    request.getOwnerId(),
+                    request.getCurrency(),
+                    request.getLabel()
+            );
+            var walletAccount = createWalletAccountUseCase.execute(tenantId, command);
+            CreateWalletAccountResponse response = new CreateWalletAccountResponse();
+            response.setAccountId(walletAccount.getId().toString());
+            response.setOwnerType(walletAccount.getOwnerType().name());
+            response.setOwnerId(walletAccount.getOwnerId());
+            response.setCurrency(walletAccount.getCurrency());
+            response.setStatus(walletAccount.getStatus().name());
+            return Response.status(Response.Status.CREATED).entity(response).build();
+        } catch (IllegalArgumentException ex) {
+            if ("wallet account already exists".equals(ex.getMessage())) {
+                throw new WebApplicationException(ex.getMessage(), Response.Status.CONFLICT);
+            }
+            throw new WebApplicationException(ex.getMessage(), Response.Status.BAD_REQUEST);
+        }
+    }
+
+    @GET
+    @Path("/{accountId}/balance")
+    public WalletBalanceResponse getBalance(@HeaderParam("X-API-Key") String apiKey,
+                                            @PathParam("accountId") UUID accountId) {
+        UUID tenantId = requireTenantId(apiKey);
+        try {
+            var balance = getWalletBalanceUseCase.execute(tenantId, accountId);
+            WalletBalanceResponse response = new WalletBalanceResponse();
+            response.setAccountId(balance.getAccountId().toString());
+            response.setBalanceMinor(balance.getBalanceMinor());
+            response.setCurrency(balance.getCurrency());
+            return response;
+        } catch (IllegalArgumentException ex) {
+            throw new WebApplicationException(ex.getMessage(), Response.Status.NOT_FOUND);
+        }
+    }
+
+    @GET
+    @Path("/{accountId}/statement")
+    public WalletStatementResponse getStatement(@HeaderParam("X-API-Key") String apiKey,
+                                                @PathParam("accountId") UUID accountId,
+                                                @QueryParam("from") Instant from,
+                                                @QueryParam("to") Instant to,
+                                                @QueryParam("page") Integer page,
+                                                @QueryParam("size") Integer size) {
+        UUID tenantId = requireTenantId(apiKey);
+        try {
+            WalletStatementPage statement = getWalletStatementUseCase.execute(
+                    tenantId,
+                    accountId,
+                    from,
+                    to,
+                    page == null ? 0 : page,
+                    size == null ? 20 : size
+            );
+
+            WalletStatementResponse response = new WalletStatementResponse();
+            response.setAccountId(statement.getAccountId().toString());
+            response.setPage(statement.getPage());
+            response.setSize(statement.getSize());
+            response.setTotal(statement.getTotal());
+            List<WalletStatementItemResponse> items = statement.getItems().stream()
+                    .map(item -> {
+                        WalletStatementItemResponse itemResponse = new WalletStatementItemResponse();
+                        itemResponse.setTransactionId(item.getTransactionId());
+                        itemResponse.setOccurredAt(item.getOccurredAt());
+                        itemResponse.setDescription(item.getDescription());
+                        itemResponse.setDirection(item.getDirection());
+                        itemResponse.setAmountMinor(item.getAmountMinor());
+                        itemResponse.setCurrency(item.getCurrency());
+                        return itemResponse;
+                    })
+                    .collect(Collectors.toList());
+            response.setItems(items);
+            return response;
+        } catch (IllegalArgumentException ex) {
+            throw new WebApplicationException(ex.getMessage(), Response.Status.NOT_FOUND);
+        }
+    }
+
+    private UUID requireTenantId(String apiKey) {
+        try {
+            return tenantResolver.resolveTenantId(apiKey);
+        } catch (IllegalArgumentException ex) {
+            throw new WebApplicationException(ex.getMessage(), Response.Status.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/WalletTransferResource.java
+++ b/src/main/java/com/sistema/wallet/api/WalletTransferResource.java
@@ -1,0 +1,62 @@
+package com.sistema.wallet.api;
+
+import com.sistema.wallet.api.dto.TransferRequest;
+import com.sistema.wallet.api.dto.TransferResponse;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.tenant.TenantResolver;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.UUID;
+
+@Path("/transfers")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class WalletTransferResource {
+    @Inject
+    TenantResolver tenantResolver;
+
+    @Inject
+    TransferBetweenWalletAccountsUseCase transferBetweenWalletAccountsUseCase;
+
+    @POST
+    public Response transfer(@HeaderParam("X-API-Key") String apiKey, TransferRequest request) {
+        UUID tenantId = requireTenantId(apiKey);
+        try {
+            TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                    request.getIdempotencyKey(),
+                    UUID.fromString(request.getFromAccountId()),
+                    UUID.fromString(request.getToAccountId()),
+                    request.getAmountMinor(),
+                    request.getCurrency(),
+                    request.getDescription()
+            );
+            var result = transferBetweenWalletAccountsUseCase.execute(tenantId, command);
+            TransferResponse response = new TransferResponse();
+            response.setTransactionId(result.getTransactionId().toString());
+            response.setStatus(result.getStatus());
+            return Response.status(Response.Status.CREATED).entity(response).build();
+        } catch (IllegalArgumentException ex) {
+            if (ex.getMessage() != null && ex.getMessage().startsWith("wallet account not found")) {
+                throw new WebApplicationException(ex.getMessage(), Response.Status.NOT_FOUND);
+            }
+            throw new WebApplicationException(ex.getMessage(), Response.Status.BAD_REQUEST);
+        }
+    }
+
+    private UUID requireTenantId(String apiKey) {
+        try {
+            return tenantResolver.resolveTenantId(apiKey);
+        } catch (IllegalArgumentException ex) {
+            throw new WebApplicationException(ex.getMessage(), Response.Status.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
@@ -1,0 +1,40 @@
+package com.sistema.wallet.api.dto;
+
+public class CreateWalletAccountRequest {
+    private String ownerType;
+    private String ownerId;
+    private String currency;
+    private String label;
+
+    public String getOwnerType() {
+        return ownerType;
+    }
+
+    public void setOwnerType(String ownerType) {
+        this.ownerType = ownerType;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountResponse.java
+++ b/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountResponse.java
@@ -1,0 +1,49 @@
+package com.sistema.wallet.api.dto;
+
+public class CreateWalletAccountResponse {
+    private String accountId;
+    private String ownerType;
+    private String ownerId;
+    private String currency;
+    private String status;
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public String getOwnerType() {
+        return ownerType;
+    }
+
+    public void setOwnerType(String ownerType) {
+        this.ownerType = ownerType;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/TransferRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/TransferRequest.java
@@ -1,0 +1,58 @@
+package com.sistema.wallet.api.dto;
+
+public class TransferRequest {
+    private String idempotencyKey;
+    private String fromAccountId;
+    private String toAccountId;
+    private long amountMinor;
+    private String currency;
+    private String description;
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getFromAccountId() {
+        return fromAccountId;
+    }
+
+    public void setFromAccountId(String fromAccountId) {
+        this.fromAccountId = fromAccountId;
+    }
+
+    public String getToAccountId() {
+        return toAccountId;
+    }
+
+    public void setToAccountId(String toAccountId) {
+        this.toAccountId = toAccountId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/TransferResponse.java
+++ b/src/main/java/com/sistema/wallet/api/dto/TransferResponse.java
@@ -1,0 +1,22 @@
+package com.sistema.wallet.api.dto;
+
+public class TransferResponse {
+    private String transactionId;
+    private String status;
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/WalletBalanceResponse.java
+++ b/src/main/java/com/sistema/wallet/api/dto/WalletBalanceResponse.java
@@ -1,0 +1,31 @@
+package com.sistema.wallet.api.dto;
+
+public class WalletBalanceResponse {
+    private String accountId;
+    private long balanceMinor;
+    private String currency;
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public long getBalanceMinor() {
+        return balanceMinor;
+    }
+
+    public void setBalanceMinor(long balanceMinor) {
+        this.balanceMinor = balanceMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/WalletStatementItemResponse.java
+++ b/src/main/java/com/sistema/wallet/api/dto/WalletStatementItemResponse.java
@@ -1,0 +1,61 @@
+package com.sistema.wallet.api.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class WalletStatementItemResponse {
+    private UUID transactionId;
+    private Instant occurredAt;
+    private String description;
+    private String direction;
+    private long amountMinor;
+    private String currency;
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(UUID transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(Instant occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public void setDirection(String direction) {
+        this.direction = direction;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/WalletStatementResponse.java
+++ b/src/main/java/com/sistema/wallet/api/dto/WalletStatementResponse.java
@@ -1,0 +1,51 @@
+package com.sistema.wallet.api.dto;
+
+import java.util.List;
+
+public class WalletStatementResponse {
+    private String accountId;
+    private List<WalletStatementItemResponse> items;
+    private int page;
+    private int size;
+    private long total;
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public List<WalletStatementItemResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<WalletStatementItemResponse> items) {
+        this.items = items;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public void setTotal(long total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
@@ -1,0 +1,70 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.CreateAccountUseCase;
+import com.sistema.ledger.application.command.CreateAccountCommand;
+import com.sistema.ledger.domain.model.AccountType;
+import com.sistema.ledger.domain.model.Account;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CreateWalletAccountUseCase {
+    private final WalletAccountRepository walletAccountRepository;
+    private final CreateAccountUseCase createAccountUseCase;
+
+    public CreateWalletAccountUseCase(WalletAccountRepository walletAccountRepository,
+                                      CreateAccountUseCase createAccountUseCase) {
+        this.walletAccountRepository = walletAccountRepository;
+        this.createAccountUseCase = createAccountUseCase;
+    }
+
+    @Transactional
+    public WalletAccount execute(UUID tenantId, CreateWalletAccountCommand command) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(command, "command");
+
+        walletAccountRepository.findByOwner(
+                tenantId,
+                command.getOwnerType(),
+                command.getOwnerId(),
+                command.getCurrency()
+        ).ifPresent(existing -> {
+            throw new IllegalArgumentException("wallet account already exists");
+        });
+
+        String ledgerAccountName = "WalletAccount " + command.getOwnerType() + ":" + command.getOwnerId();
+        boolean allowNegative = command.getOwnerType() == WalletOwnerType.INTERNAL;
+        Account ledgerAccount = createAccountUseCase.execute(
+                new CreateAccountCommand(
+                        tenantId,
+                        ledgerAccountName,
+                        AccountType.LIABILITY,
+                        command.getCurrency(),
+                        allowNegative
+                )
+        );
+
+        WalletAccount walletAccount = new WalletAccount(
+                UUID.randomUUID(),
+                tenantId,
+                command.getOwnerType(),
+                command.getOwnerId(),
+                command.getCurrency(),
+                WalletAccountStatus.ACTIVE,
+                command.getLabel(),
+                ledgerAccount.getId(),
+                Instant.now()
+        );
+
+        return walletAccountRepository.save(walletAccount);
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/GetWalletBalanceUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/GetWalletBalanceUseCase.java
@@ -1,0 +1,28 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountBalanceUseCase;
+import com.sistema.wallet.application.model.WalletBalance;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.UUID;
+
+@ApplicationScoped
+public class GetWalletBalanceUseCase {
+    private final WalletAccountRepository walletAccountRepository;
+    private final GetAccountBalanceUseCase getAccountBalanceUseCase;
+
+    public GetWalletBalanceUseCase(WalletAccountRepository walletAccountRepository,
+                                   GetAccountBalanceUseCase getAccountBalanceUseCase) {
+        this.walletAccountRepository = walletAccountRepository;
+        this.getAccountBalanceUseCase = getAccountBalanceUseCase;
+    }
+
+    public WalletBalance execute(UUID tenantId, UUID accountId) {
+        WalletAccount walletAccount = walletAccountRepository.findById(tenantId, accountId)
+                .orElseThrow(() -> new IllegalArgumentException("wallet account not found: " + accountId));
+        var balance = getAccountBalanceUseCase.execute(tenantId, walletAccount.getLedgerAccountId());
+        return new WalletBalance(walletAccount.getId(), balance.getBalanceMinor(), balance.getCurrency());
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/GetWalletStatementUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/GetWalletStatementUseCase.java
@@ -1,0 +1,52 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountStatementUseCase;
+import com.sistema.wallet.application.model.WalletStatementItem;
+import com.sistema.wallet.application.model.WalletStatementPage;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class GetWalletStatementUseCase {
+    private final WalletAccountRepository walletAccountRepository;
+    private final GetAccountStatementUseCase getAccountStatementUseCase;
+
+    public GetWalletStatementUseCase(WalletAccountRepository walletAccountRepository,
+                                     GetAccountStatementUseCase getAccountStatementUseCase) {
+        this.walletAccountRepository = walletAccountRepository;
+        this.getAccountStatementUseCase = getAccountStatementUseCase;
+    }
+
+    public WalletStatementPage execute(UUID tenantId, UUID accountId, Instant from, Instant to, int page, int size) {
+        WalletAccount walletAccount = walletAccountRepository.findById(tenantId, accountId)
+                .orElseThrow(() -> new IllegalArgumentException("wallet account not found: " + accountId));
+
+        var statement = getAccountStatementUseCase.execute(
+                tenantId,
+                walletAccount.getLedgerAccountId(),
+                from,
+                to,
+                page,
+                size
+        );
+
+        List<WalletStatementItem> items = statement.getItems().stream()
+                .map(item -> new WalletStatementItem(
+                        item.getOccurredAt(),
+                        item.getTransactionId(),
+                        item.getDescription(),
+                        item.getDirection().name(),
+                        item.getAmountMinor(),
+                        item.getCurrency()
+                ))
+                .collect(Collectors.toList());
+
+        return new WalletStatementPage(walletAccount.getId(), items, statement.getPage(), statement.getSize(), statement.getTotal());
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
@@ -1,0 +1,94 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountBalanceUseCase;
+import com.sistema.ledger.application.PostLedgerTransactionUseCase;
+import com.sistema.ledger.application.command.PostLedgerTransactionCommand;
+import com.sistema.ledger.application.command.PostingEntryCommand;
+import com.sistema.ledger.domain.model.EntryDirection;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.model.WalletTransferResult;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class TransferBetweenWalletAccountsUseCase {
+    private final WalletAccountRepository walletAccountRepository;
+    private final GetAccountBalanceUseCase getAccountBalanceUseCase;
+    private final PostLedgerTransactionUseCase postLedgerTransactionUseCase;
+
+    public TransferBetweenWalletAccountsUseCase(WalletAccountRepository walletAccountRepository,
+                                                GetAccountBalanceUseCase getAccountBalanceUseCase,
+                                                PostLedgerTransactionUseCase postLedgerTransactionUseCase) {
+        this.walletAccountRepository = walletAccountRepository;
+        this.getAccountBalanceUseCase = getAccountBalanceUseCase;
+        this.postLedgerTransactionUseCase = postLedgerTransactionUseCase;
+    }
+
+    @Transactional
+    public WalletTransferResult execute(UUID tenantId, TransferBetweenWalletAccountsCommand command) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(command, "command");
+        if (command.getAmountMinor() <= 0) {
+            System.out.println("TransferBetweenWalletAccounts: invalid amount " + command.getAmountMinor());
+            throw new IllegalArgumentException("amount must be greater than zero");
+        }
+        if (command.getIdempotencyKey() == null || command.getIdempotencyKey().isBlank()) {
+            System.out.println("TransferBetweenWalletAccounts: missing idempotencyKey");
+            throw new IllegalArgumentException("idempotencyKey is required");
+        }
+
+        WalletAccount fromAccount = walletAccountRepository.findById(tenantId, command.getFromAccountId())
+                .orElseThrow(() -> {
+                    System.out.println("TransferBetweenWalletAccounts: fromAccount not found " + command.getFromAccountId());
+                    return new IllegalArgumentException("wallet account not found: " + command.getFromAccountId());
+                });
+        WalletAccount toAccount = walletAccountRepository.findById(tenantId, command.getToAccountId())
+                .orElseThrow(() -> {
+                    System.out.println("TransferBetweenWalletAccounts: toAccount not found " + command.getToAccountId());
+                    return new IllegalArgumentException("wallet account not found: " + command.getToAccountId());
+                });
+
+        if (!fromAccount.getCurrency().equals(command.getCurrency())
+                || !toAccount.getCurrency().equals(command.getCurrency())) {
+            System.out.println("TransferBetweenWalletAccounts: currency mismatch from=" + fromAccount.getCurrency()
+                    + " to=" + toAccount.getCurrency() + " requested=" + command.getCurrency());
+            throw new IllegalArgumentException("currency mismatch");
+        }
+
+        var fromBalance = getAccountBalanceUseCase.execute(tenantId, fromAccount.getLedgerAccountId());
+        if (fromAccount.getOwnerType() != com.sistema.wallet.domain.model.WalletOwnerType.INTERNAL
+                && fromBalance.getBalanceMinor() < command.getAmountMinor()) {
+            System.out.println("TransferBetweenWalletAccounts: insufficient balance " + fromBalance.getBalanceMinor()
+                    + " < " + command.getAmountMinor());
+            throw new IllegalArgumentException("insufficient balance");
+        }
+
+        PostLedgerTransactionCommand ledgerCommand = new PostLedgerTransactionCommand(
+                tenantId,
+                command.getIdempotencyKey(),
+                null,
+                command.getDescription(),
+                Instant.now(),
+                List.of(
+                        new PostingEntryCommand(fromAccount.getLedgerAccountId(), EntryDirection.DEBIT, command.getAmountMinor(), command.getCurrency()),
+                        new PostingEntryCommand(toAccount.getLedgerAccountId(), EntryDirection.CREDIT, command.getAmountMinor(), command.getCurrency())
+                )
+        );
+
+        try {
+            var transaction = postLedgerTransactionUseCase.execute(ledgerCommand);
+            return new WalletTransferResult(transaction.getId(), "POSTED");
+        } catch (RuntimeException ex) {
+            System.out.println("TransferBetweenWalletAccounts: ledger transfer failed idempotencyKey="
+                    + command.getIdempotencyKey() + " message=" + ex.getMessage());
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/command/CreateWalletAccountCommand.java
+++ b/src/main/java/com/sistema/wallet/application/command/CreateWalletAccountCommand.java
@@ -1,0 +1,33 @@
+package com.sistema.wallet.application.command;
+
+import com.sistema.wallet.domain.model.WalletOwnerType;
+
+public class CreateWalletAccountCommand {
+    private final WalletOwnerType ownerType;
+    private final String ownerId;
+    private final String currency;
+    private final String label;
+
+    public CreateWalletAccountCommand(WalletOwnerType ownerType, String ownerId, String currency, String label) {
+        this.ownerType = ownerType;
+        this.ownerId = ownerId;
+        this.currency = currency;
+        this.label = label;
+    }
+
+    public WalletOwnerType getOwnerType() {
+        return ownerType;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/command/TransferBetweenWalletAccountsCommand.java
+++ b/src/main/java/com/sistema/wallet/application/command/TransferBetweenWalletAccountsCommand.java
@@ -1,0 +1,50 @@
+package com.sistema.wallet.application.command;
+
+import java.util.UUID;
+
+public class TransferBetweenWalletAccountsCommand {
+    private final String idempotencyKey;
+    private final UUID fromAccountId;
+    private final UUID toAccountId;
+    private final long amountMinor;
+    private final String currency;
+    private final String description;
+
+    public TransferBetweenWalletAccountsCommand(String idempotencyKey,
+                                                UUID fromAccountId,
+                                                UUID toAccountId,
+                                                long amountMinor,
+                                                String currency,
+                                                String description) {
+        this.idempotencyKey = idempotencyKey;
+        this.fromAccountId = fromAccountId;
+        this.toAccountId = toAccountId;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.description = description;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public UUID getFromAccountId() {
+        return fromAccountId;
+    }
+
+    public UUID getToAccountId() {
+        return toAccountId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/model/WalletBalance.java
+++ b/src/main/java/com/sistema/wallet/application/model/WalletBalance.java
@@ -1,0 +1,27 @@
+package com.sistema.wallet.application.model;
+
+import java.util.UUID;
+
+public class WalletBalance {
+    private final UUID accountId;
+    private final long balanceMinor;
+    private final String currency;
+
+    public WalletBalance(UUID accountId, long balanceMinor, String currency) {
+        this.accountId = accountId;
+        this.balanceMinor = balanceMinor;
+        this.currency = currency;
+    }
+
+    public UUID getAccountId() {
+        return accountId;
+    }
+
+    public long getBalanceMinor() {
+        return balanceMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/model/WalletStatementItem.java
+++ b/src/main/java/com/sistema/wallet/application/model/WalletStatementItem.java
@@ -1,0 +1,51 @@
+package com.sistema.wallet.application.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class WalletStatementItem {
+    private final Instant occurredAt;
+    private final UUID transactionId;
+    private final String description;
+    private final String direction;
+    private final long amountMinor;
+    private final String currency;
+
+    public WalletStatementItem(Instant occurredAt,
+                               UUID transactionId,
+                               String description,
+                               String direction,
+                               long amountMinor,
+                               String currency) {
+        this.occurredAt = occurredAt;
+        this.transactionId = transactionId;
+        this.description = description;
+        this.direction = direction;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/model/WalletStatementPage.java
+++ b/src/main/java/com/sistema/wallet/application/model/WalletStatementPage.java
@@ -1,0 +1,40 @@
+package com.sistema.wallet.application.model;
+
+import java.util.List;
+import java.util.UUID;
+
+public class WalletStatementPage {
+    private final UUID accountId;
+    private final List<WalletStatementItem> items;
+    private final int page;
+    private final int size;
+    private final long total;
+
+    public WalletStatementPage(UUID accountId, List<WalletStatementItem> items, int page, int size, long total) {
+        this.accountId = accountId;
+        this.items = items;
+        this.page = page;
+        this.size = size;
+        this.total = total;
+    }
+
+    public UUID getAccountId() {
+        return accountId;
+    }
+
+    public List<WalletStatementItem> getItems() {
+        return items;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/model/WalletTransferResult.java
+++ b/src/main/java/com/sistema/wallet/application/model/WalletTransferResult.java
@@ -1,0 +1,21 @@
+package com.sistema.wallet.application.model;
+
+import java.util.UUID;
+
+public class WalletTransferResult {
+    private final UUID transactionId;
+    private final String status;
+
+    public WalletTransferResult(UUID transactionId, String status) {
+        this.transactionId = transactionId;
+        this.status = status;
+    }
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/tenant/TenantResolver.java
+++ b/src/main/java/com/sistema/wallet/application/tenant/TenantResolver.java
@@ -1,0 +1,7 @@
+package com.sistema.wallet.application.tenant;
+
+import java.util.UUID;
+
+public interface TenantResolver {
+    UUID resolveTenantId(String apiKey);
+}

--- a/src/main/java/com/sistema/wallet/domain/model/WalletAccount.java
+++ b/src/main/java/com/sistema/wallet/domain/model/WalletAccount.java
@@ -1,0 +1,79 @@
+package com.sistema.wallet.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public class WalletAccount {
+    private final UUID id;
+    private final UUID tenantId;
+    private final WalletOwnerType ownerType;
+    private final String ownerId;
+    private final String currency;
+    private final WalletAccountStatus status;
+    private final String label;
+    private final UUID ledgerAccountId;
+    private final Instant createdAt;
+
+    public WalletAccount(UUID id,
+                         UUID tenantId,
+                         WalletOwnerType ownerType,
+                         String ownerId,
+                         String currency,
+                         WalletAccountStatus status,
+                         String label,
+                         UUID ledgerAccountId,
+                         Instant createdAt) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.ownerType = Objects.requireNonNull(ownerType, "ownerType");
+        this.ownerId = Objects.requireNonNull(ownerId, "ownerId");
+        if (this.ownerId.isBlank()) {
+            throw new IllegalArgumentException("ownerId must not be blank");
+        }
+        this.currency = Objects.requireNonNull(currency, "currency");
+        if (this.currency.isBlank()) {
+            throw new IllegalArgumentException("currency must not be blank");
+        }
+        this.status = Objects.requireNonNull(status, "status");
+        this.label = label;
+        this.ledgerAccountId = Objects.requireNonNull(ledgerAccountId, "ledgerAccountId");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public WalletOwnerType getOwnerType() {
+        return ownerType;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public WalletAccountStatus getStatus() {
+        return status;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public UUID getLedgerAccountId() {
+        return ledgerAccountId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/sistema/wallet/domain/model/WalletAccountStatus.java
+++ b/src/main/java/com/sistema/wallet/domain/model/WalletAccountStatus.java
@@ -1,0 +1,6 @@
+package com.sistema.wallet.domain.model;
+
+public enum WalletAccountStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
+++ b/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
@@ -1,0 +1,6 @@
+package com.sistema.wallet.domain.model;
+
+public enum WalletOwnerType {
+    CUSTOMER,
+    INTERNAL
+}

--- a/src/main/java/com/sistema/wallet/domain/repository/WalletAccountRepository.java
+++ b/src/main/java/com/sistema/wallet/domain/repository/WalletAccountRepository.java
@@ -1,0 +1,15 @@
+package com.sistema.wallet.domain.repository;
+
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface WalletAccountRepository {
+    WalletAccount save(WalletAccount walletAccount);
+
+    Optional<WalletAccount> findById(UUID tenantId, UUID accountId);
+
+    Optional<WalletAccount> findByOwner(UUID tenantId, WalletOwnerType ownerType, String ownerId, String currency);
+}

--- a/src/main/java/com/sistema/wallet/infra/entity/WalletAccountEntity.java
+++ b/src/main/java/com/sistema/wallet/infra/entity/WalletAccountEntity.java
@@ -1,0 +1,112 @@
+package com.sistema.wallet.infra.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "wallet_accounts")
+public class WalletAccountEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "tenant_id")
+    private UUID tenantId;
+
+    @Column(name = "owner_type")
+    private String ownerType;
+
+    @Column(name = "owner_id")
+    private String ownerId;
+
+    @Column(name = "currency")
+    private String currency;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "label")
+    private String label;
+
+    @Column(name = "ledger_account_id")
+    private UUID ledgerAccountId;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getOwnerType() {
+        return ownerType;
+    }
+
+    public void setOwnerType(String ownerType) {
+        this.ownerType = ownerType;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public UUID getLedgerAccountId() {
+        return ledgerAccountId;
+    }
+
+    public void setLedgerAccountId(UUID ledgerAccountId) {
+        this.ledgerAccountId = ledgerAccountId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sistema/wallet/infra/mapper/WalletEntityMapper.java
+++ b/src/main/java/com/sistema/wallet/infra/mapper/WalletEntityMapper.java
@@ -1,0 +1,39 @@
+package com.sistema.wallet.infra.mapper;
+
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.infra.entity.WalletAccountEntity;
+
+public final class WalletEntityMapper {
+    private WalletEntityMapper() {
+    }
+
+    public static WalletAccountEntity toEntity(WalletAccount walletAccount) {
+        WalletAccountEntity entity = new WalletAccountEntity();
+        entity.setId(walletAccount.getId());
+        entity.setTenantId(walletAccount.getTenantId());
+        entity.setOwnerType(walletAccount.getOwnerType().name());
+        entity.setOwnerId(walletAccount.getOwnerId());
+        entity.setCurrency(walletAccount.getCurrency());
+        entity.setStatus(walletAccount.getStatus().name());
+        entity.setLabel(walletAccount.getLabel());
+        entity.setLedgerAccountId(walletAccount.getLedgerAccountId());
+        entity.setCreatedAt(walletAccount.getCreatedAt());
+        return entity;
+    }
+
+    public static WalletAccount toDomain(WalletAccountEntity entity) {
+        return new WalletAccount(
+                entity.getId(),
+                entity.getTenantId(),
+                WalletOwnerType.valueOf(entity.getOwnerType()),
+                entity.getOwnerId(),
+                entity.getCurrency(),
+                WalletAccountStatus.valueOf(entity.getStatus()),
+                entity.getLabel(),
+                entity.getLedgerAccountId(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sistema/wallet/infra/repository/WalletAccountRepositoryAdapter.java
+++ b/src/main/java/com/sistema/wallet/infra/repository/WalletAccountRepositoryAdapter.java
@@ -1,0 +1,47 @@
+package com.sistema.wallet.infra.repository;
+
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import com.sistema.wallet.infra.entity.WalletAccountEntity;
+import com.sistema.wallet.infra.mapper.WalletEntityMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class WalletAccountRepositoryAdapter implements WalletAccountRepository, PanacheRepository<WalletAccountEntity> {
+    @Override
+    public WalletAccount save(WalletAccount walletAccount) {
+        WalletAccountEntity entity = WalletEntityMapper.toEntity(walletAccount);
+        persist(entity);
+        getEntityManager().flush();
+        return WalletEntityMapper.toDomain(entity);
+    }
+
+    @Override
+    public Optional<WalletAccount> findById(UUID tenantId, UUID accountId) {
+        WalletAccountEntity entity = find("tenantId = ?1 and id = ?2", tenantId, accountId).firstResult();
+        if (entity == null) {
+            return Optional.empty();
+        }
+        return Optional.of(WalletEntityMapper.toDomain(entity));
+    }
+
+    @Override
+    public Optional<WalletAccount> findByOwner(UUID tenantId, WalletOwnerType ownerType, String ownerId, String currency) {
+        WalletAccountEntity entity = find(
+                "tenantId = ?1 and ownerType = ?2 and ownerId = ?3 and currency = ?4",
+                tenantId,
+                ownerType.name(),
+                ownerId,
+                currency
+        ).firstResult();
+        if (entity == null) {
+            return Optional.empty();
+        }
+        return Optional.of(WalletEntityMapper.toDomain(entity));
+    }
+}

--- a/src/main/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolver.java
+++ b/src/main/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolver.java
@@ -1,0 +1,50 @@
+package com.sistema.wallet.infra.tenant;
+
+import com.sistema.wallet.application.tenant.TenantResolver;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class ApiKeyTenantResolver implements TenantResolver {
+    private final Map<String, UUID> apiKeyToTenant = new HashMap<>();
+
+    public ApiKeyTenantResolver(@ConfigProperty(name = "wallet.api-keys") Optional<String> apiKeys) {
+        String resolved = apiKeys.orElse("");
+        if (resolved.isBlank()) {
+            return;
+        }
+        String[] pairs = resolved.split(",");
+        for (String pair : pairs) {
+            String trimmed = pair.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String[] parts = trimmed.split("=");
+            if (parts.length != 2) {
+                continue;
+            }
+            String key = parts[0].trim();
+            String value = parts[1].trim();
+            if (!key.isEmpty() && !value.isEmpty()) {
+                apiKeyToTenant.put(key, UUID.fromString(value));
+            }
+        }
+    }
+
+    @Override
+    public UUID resolveTenantId(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalArgumentException("apiKey is required");
+        }
+        UUID tenantId = apiKeyToTenant.get(apiKey);
+        if (tenantId == null) {
+            throw new IllegalArgumentException("apiKey not recognized");
+        }
+        return tenantId;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 quarkus.datasource.username=sa
 quarkus.datasource.password=
+wallet.api-keys=key-dev=00000000-0000-0000-0000-000000000000

--- a/src/main/resources/db/migration/V3__wallet_accounts.sql
+++ b/src/main/resources/db/migration/V3__wallet_accounts.sql
@@ -1,0 +1,24 @@
+create table if not exists wallet_accounts (
+    id uuid primary key,
+    tenant_id uuid not null,
+    owner_type varchar(32) not null,
+    owner_id varchar(255) not null,
+    currency varchar(16) not null,
+    status varchar(32) not null,
+    label varchar(255),
+    ledger_account_id uuid not null,
+    created_at timestamp not null,
+    constraint fk_wallet_accounts_tenant
+        foreign key (tenant_id) references tenants (id),
+    constraint fk_wallet_accounts_ledger_account
+        foreign key (ledger_account_id) references ledger_accounts (id)
+);
+
+create unique index if not exists uq_wallet_accounts_owner_currency
+    on wallet_accounts (tenant_id, owner_type, owner_id, currency);
+
+create index if not exists idx_wallet_accounts_tenant_owner
+    on wallet_accounts (tenant_id, owner_id);
+
+create index if not exists idx_wallet_accounts_tenant_ledger_account
+    on wallet_accounts (tenant_id, ledger_account_id);

--- a/src/test/java/com/sistema/infraestrutura/repositorio/DbCleanIT.java
+++ b/src/test/java/com/sistema/infraestrutura/repositorio/DbCleanIT.java
@@ -37,6 +37,17 @@ public abstract class DbCleanIT {
             }
 
             st.execute("SET REFERENTIAL_INTEGRITY TRUE");
+
+            try (ResultSet rs = st.executeQuery(
+                    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES " +
+                            "WHERE TABLE_SCHEMA='PUBLIC' AND TABLE_NAME='TENANTS'")) {
+                if (rs.next() && rs.getInt(1) > 0) {
+                    st.executeUpdate(
+                            "INSERT INTO tenants (id, name, status, created_at) " +
+                                    "VALUES ('00000000-0000-0000-0000-000000000000', 'DEFAULT', 'ACTIVE', CURRENT_TIMESTAMP)"
+                    );
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/sistema/wallet/application/CreateWalletAccountUseCaseTest.java
+++ b/src/test/java/com/sistema/wallet/application/CreateWalletAccountUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.CreateAccountUseCase;
+import com.sistema.ledger.application.command.CreateAccountCommand;
+import com.sistema.ledger.domain.model.Account;
+import com.sistema.ledger.domain.model.AccountStatus;
+import com.sistema.ledger.domain.model.AccountType;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CreateWalletAccountUseCaseTest {
+
+    @Test
+    void shouldCreateWalletAccountWhenUnique() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        CreateAccountUseCase createAccountUseCase = Mockito.mock(CreateAccountUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        CreateWalletAccountCommand command = new CreateWalletAccountCommand(
+                WalletOwnerType.CUSTOMER,
+                "user-123",
+                "BRL",
+                "Main Wallet"
+        );
+
+        when(walletAccountRepository.findByOwner(tenantId, WalletOwnerType.CUSTOMER, "user-123", "BRL"))
+                .thenReturn(Optional.empty());
+
+        UUID ledgerAccountId = UUID.randomUUID();
+        when(createAccountUseCase.execute(any(CreateAccountCommand.class)))
+                .thenReturn(new Account(
+                        ledgerAccountId,
+                        tenantId,
+                        "Ledger Wallet",
+                        AccountType.LIABILITY,
+                        "BRL",
+                        false,
+                        AccountStatus.ACTIVE,
+                        Instant.now()
+                ));
+
+        when(walletAccountRepository.save(any(WalletAccount.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CreateWalletAccountUseCase useCase = new CreateWalletAccountUseCase(walletAccountRepository, createAccountUseCase);
+
+        WalletAccount walletAccount = useCase.execute(tenantId, command);
+
+        assertNotNull(walletAccount.getId());
+        assertEquals(tenantId, walletAccount.getTenantId());
+        assertEquals(WalletOwnerType.CUSTOMER, walletAccount.getOwnerType());
+        assertEquals("user-123", walletAccount.getOwnerId());
+        assertEquals("BRL", walletAccount.getCurrency());
+        assertEquals(WalletAccountStatus.ACTIVE, walletAccount.getStatus());
+        assertEquals("Main Wallet", walletAccount.getLabel());
+        assertEquals(ledgerAccountId, walletAccount.getLedgerAccountId());
+
+        ArgumentCaptor<CreateAccountCommand> commandCaptor = ArgumentCaptor.forClass(CreateAccountCommand.class);
+        verify(createAccountUseCase).execute(commandCaptor.capture());
+        CreateAccountCommand ledgerCommand = commandCaptor.getValue();
+        assertEquals(tenantId, ledgerCommand.getTenantId());
+        assertEquals(AccountType.LIABILITY, ledgerCommand.getType());
+        assertEquals("BRL", ledgerCommand.getCurrency());
+        assertEquals(false, ledgerCommand.isAllowNegative());
+    }
+
+    @Test
+    void shouldRejectDuplicateWalletAccount() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        CreateAccountUseCase createAccountUseCase = Mockito.mock(CreateAccountUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        CreateWalletAccountCommand command = new CreateWalletAccountCommand(
+                WalletOwnerType.CUSTOMER,
+                "user-123",
+                "BRL",
+                null
+        );
+
+        WalletAccount existing = new WalletAccount(
+                UUID.randomUUID(),
+                tenantId,
+                WalletOwnerType.CUSTOMER,
+                "user-123",
+                "BRL",
+                WalletAccountStatus.ACTIVE,
+                null,
+                UUID.randomUUID(),
+                Instant.now()
+        );
+        when(walletAccountRepository.findByOwner(tenantId, WalletOwnerType.CUSTOMER, "user-123", "BRL"))
+                .thenReturn(Optional.of(existing));
+
+        CreateWalletAccountUseCase useCase = new CreateWalletAccountUseCase(walletAccountRepository, createAccountUseCase);
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, command));
+        verify(createAccountUseCase, never()).execute(any(CreateAccountCommand.class));
+    }
+}

--- a/src/test/java/com/sistema/wallet/application/GetWalletBalanceUseCaseTest.java
+++ b/src/test/java/com/sistema/wallet/application/GetWalletBalanceUseCaseTest.java
@@ -1,0 +1,70 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountBalanceUseCase;
+import com.sistema.ledger.application.model.AccountBalance;
+import com.sistema.wallet.application.model.WalletBalance;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class GetWalletBalanceUseCaseTest {
+
+    @Test
+    void shouldReturnBalanceForWalletAccount() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID walletAccountId = UUID.randomUUID();
+        UUID ledgerAccountId = UUID.randomUUID();
+
+        WalletAccount walletAccount = new WalletAccount(
+                walletAccountId,
+                tenantId,
+                WalletOwnerType.CUSTOMER,
+                "user-1",
+                "BRL",
+                WalletAccountStatus.ACTIVE,
+                null,
+                ledgerAccountId,
+                Instant.now()
+        );
+
+        when(walletAccountRepository.findById(tenantId, walletAccountId)).thenReturn(Optional.of(walletAccount));
+        when(getAccountBalanceUseCase.execute(tenantId, ledgerAccountId))
+                .thenReturn(new AccountBalance(ledgerAccountId, 2500L, "BRL"));
+
+        GetWalletBalanceUseCase useCase = new GetWalletBalanceUseCase(walletAccountRepository, getAccountBalanceUseCase);
+        WalletBalance balance = useCase.execute(tenantId, walletAccountId);
+
+        assertEquals(walletAccountId, balance.getAccountId());
+        assertEquals(2500L, balance.getBalanceMinor());
+        assertEquals("BRL", balance.getCurrency());
+    }
+
+    @Test
+    void shouldThrowWhenWalletAccountNotFound() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID walletAccountId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, walletAccountId)).thenReturn(Optional.empty());
+
+        GetWalletBalanceUseCase useCase = new GetWalletBalanceUseCase(walletAccountRepository, getAccountBalanceUseCase);
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, walletAccountId));
+    }
+}

--- a/src/test/java/com/sistema/wallet/application/GetWalletStatementUseCaseTest.java
+++ b/src/test/java/com/sistema/wallet/application/GetWalletStatementUseCaseTest.java
@@ -1,0 +1,89 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountStatementUseCase;
+import com.sistema.ledger.application.model.StatementItem;
+import com.sistema.ledger.application.model.StatementPage;
+import com.sistema.ledger.domain.model.EntryDirection;
+import com.sistema.wallet.application.model.WalletStatementPage;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class GetWalletStatementUseCaseTest {
+
+    @Test
+    void shouldReturnStatementFromLedger() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountStatementUseCase getAccountStatementUseCase = Mockito.mock(GetAccountStatementUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID walletAccountId = UUID.randomUUID();
+        UUID ledgerAccountId = UUID.randomUUID();
+
+        WalletAccount walletAccount = new WalletAccount(
+                walletAccountId,
+                tenantId,
+                WalletOwnerType.CUSTOMER,
+                "user-1",
+                "BRL",
+                WalletAccountStatus.ACTIVE,
+                null,
+                ledgerAccountId,
+                Instant.now()
+        );
+
+        when(walletAccountRepository.findById(tenantId, walletAccountId)).thenReturn(Optional.of(walletAccount));
+
+        StatementPage ledgerStatement = new StatementPage(
+                ledgerAccountId,
+                List.of(new StatementItem(
+                        Instant.parse("2026-01-20T10:00:00Z"),
+                        UUID.randomUUID(),
+                        "Transfer",
+                        EntryDirection.DEBIT,
+                        5000,
+                        "BRL"
+                )),
+                0,
+                20,
+                1
+        );
+
+        when(getAccountStatementUseCase.execute(tenantId, ledgerAccountId, null, null, 0, 20))
+                .thenReturn(ledgerStatement);
+
+        GetWalletStatementUseCase useCase = new GetWalletStatementUseCase(walletAccountRepository, getAccountStatementUseCase);
+        WalletStatementPage statement = useCase.execute(tenantId, walletAccountId, null, null, 0, 20);
+
+        assertEquals(walletAccountId, statement.getAccountId());
+        assertEquals(1, statement.getItems().size());
+        assertEquals("DEBIT", statement.getItems().get(0).getDirection());
+    }
+
+    @Test
+    void shouldThrowWhenWalletAccountNotFound() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountStatementUseCase getAccountStatementUseCase = Mockito.mock(GetAccountStatementUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID walletAccountId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, walletAccountId)).thenReturn(Optional.empty());
+
+        GetWalletStatementUseCase useCase = new GetWalletStatementUseCase(walletAccountRepository, getAccountStatementUseCase);
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, walletAccountId, null, null, 0, 20));
+    }
+}

--- a/src/test/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCaseTest.java
+++ b/src/test/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCaseTest.java
@@ -1,0 +1,232 @@
+package com.sistema.wallet.application;
+
+import com.sistema.ledger.application.GetAccountBalanceUseCase;
+import com.sistema.ledger.application.PostLedgerTransactionUseCase;
+import com.sistema.ledger.application.model.AccountBalance;
+import com.sistema.ledger.domain.model.Entry;
+import com.sistema.ledger.domain.model.EntryDirection;
+import com.sistema.ledger.domain.model.IdempotencyKey;
+import com.sistema.ledger.domain.model.LedgerTransaction;
+import com.sistema.ledger.domain.model.Money;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.model.WalletTransferResult;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransferBetweenWalletAccountsUseCaseTest {
+
+    @Test
+    void shouldTransferBetweenAccounts() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID fromWalletId = UUID.randomUUID();
+        UUID toWalletId = UUID.randomUUID();
+        UUID fromLedgerId = UUID.randomUUID();
+        UUID toLedgerId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, fromWalletId))
+                .thenReturn(Optional.of(walletAccount(fromWalletId, tenantId, fromLedgerId, "BRL")));
+        when(walletAccountRepository.findById(tenantId, toWalletId))
+                .thenReturn(Optional.of(walletAccount(toWalletId, tenantId, toLedgerId, "BRL")));
+
+        when(getAccountBalanceUseCase.execute(tenantId, fromLedgerId))
+                .thenReturn(new AccountBalance(fromLedgerId, 10000, "BRL"));
+
+        LedgerTransaction ledgerTransaction = new LedgerTransaction(
+                UUID.randomUUID(),
+                tenantId,
+                new IdempotencyKey("idemp-1"),
+                null,
+                "transfer",
+                Instant.now(),
+                Instant.now(),
+                List.of(
+                        entry(fromLedgerId, tenantId, EntryDirection.DEBIT, 5000),
+                        entry(toLedgerId, tenantId, EntryDirection.CREDIT, 5000)
+                )
+        );
+        when(postLedgerTransactionUseCase.execute(any())).thenReturn(ledgerTransaction);
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                "idemp-1",
+                fromWalletId,
+                toWalletId,
+                5000,
+                "BRL",
+                "transfer"
+        );
+
+        WalletTransferResult result = useCase.execute(tenantId, command);
+
+        assertEquals(ledgerTransaction.getId(), result.getTransactionId());
+        assertEquals("POSTED", result.getStatus());
+    }
+
+    @Test
+    void shouldRejectInsufficientBalance() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID fromWalletId = UUID.randomUUID();
+        UUID toWalletId = UUID.randomUUID();
+        UUID fromLedgerId = UUID.randomUUID();
+        UUID toLedgerId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, fromWalletId))
+                .thenReturn(Optional.of(walletAccount(fromWalletId, tenantId, fromLedgerId, "BRL")));
+        when(walletAccountRepository.findById(tenantId, toWalletId))
+                .thenReturn(Optional.of(walletAccount(toWalletId, tenantId, toLedgerId, "BRL")));
+
+        when(getAccountBalanceUseCase.execute(tenantId, fromLedgerId))
+                .thenReturn(new AccountBalance(fromLedgerId, 100, "BRL"));
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                "idemp-2",
+                fromWalletId,
+                toWalletId,
+                5000,
+                "BRL",
+                "transfer"
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, command));
+        verify(postLedgerTransactionUseCase, never()).execute(any());
+    }
+
+    @Test
+    void shouldRejectCurrencyMismatch() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID fromWalletId = UUID.randomUUID();
+        UUID toWalletId = UUID.randomUUID();
+        UUID fromLedgerId = UUID.randomUUID();
+        UUID toLedgerId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, fromWalletId))
+                .thenReturn(Optional.of(walletAccount(fromWalletId, tenantId, fromLedgerId, "BRL")));
+        when(walletAccountRepository.findById(tenantId, toWalletId))
+                .thenReturn(Optional.of(walletAccount(toWalletId, tenantId, toLedgerId, "USD")));
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                "idemp-3",
+                fromWalletId,
+                toWalletId,
+                5000,
+                "BRL",
+                "transfer"
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, command));
+        verify(postLedgerTransactionUseCase, never()).execute(any());
+    }
+
+    @Test
+    void shouldRejectInvalidInput() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                " ",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                0,
+                "BRL",
+                "transfer"
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(UUID.randomUUID(), command));
+        verify(postLedgerTransactionUseCase, never()).execute(any());
+    }
+
+    @Test
+    void shouldRejectWhenWalletAccountMissing() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID fromWalletId = UUID.randomUUID();
+        UUID toWalletId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, fromWalletId)).thenReturn(Optional.empty());
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                "idemp-4",
+                fromWalletId,
+                toWalletId,
+                5000,
+                "BRL",
+                "transfer"
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, command));
+        verify(postLedgerTransactionUseCase, never()).execute(any());
+    }
+
+    private WalletAccount walletAccount(UUID walletId, UUID tenantId, UUID ledgerAccountId, String currency) {
+        return new WalletAccount(
+                walletId,
+                tenantId,
+                WalletOwnerType.CUSTOMER,
+                "user",
+                currency,
+                WalletAccountStatus.ACTIVE,
+                null,
+                ledgerAccountId,
+                Instant.now()
+        );
+    }
+
+    private Entry entry(UUID ledgerAccountId, UUID tenantId, EntryDirection direction, long amountMinor) {
+        return new Entry(
+                UUID.randomUUID(),
+                tenantId,
+                UUID.randomUUID(),
+                ledgerAccountId,
+                direction,
+                new Money(amountMinor, "BRL"),
+                Instant.now(),
+                Instant.now()
+        );
+    }
+}

--- a/src/test/java/com/sistema/wallet/infra/WalletIntegrationTest.java
+++ b/src/test/java/com/sistema/wallet/infra/WalletIntegrationTest.java
@@ -1,0 +1,177 @@
+package com.sistema.wallet.infra;
+
+import com.sistema.infraestrutura.repositorio.DbCleanIT;
+import com.sistema.ledger.application.CreateAccountUseCase;
+import com.sistema.ledger.application.PostLedgerTransactionUseCase;
+import com.sistema.ledger.application.command.CreateAccountCommand;
+import com.sistema.ledger.application.command.PostLedgerTransactionCommand;
+import com.sistema.ledger.application.command.PostingEntryCommand;
+import com.sistema.ledger.domain.model.AccountType;
+import com.sistema.ledger.domain.model.EntryDirection;
+import com.sistema.wallet.application.CreateWalletAccountUseCase;
+import com.sistema.wallet.application.GetWalletBalanceUseCase;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@QuarkusTest
+class WalletIntegrationTest extends DbCleanIT {
+
+    private static final UUID DEFAULT_TENANT = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Inject
+    CreateWalletAccountUseCase createWalletAccountUseCase;
+
+    @Inject
+    GetWalletBalanceUseCase getWalletBalanceUseCase;
+
+    @Inject
+    TransferBetweenWalletAccountsUseCase transferBetweenWalletAccountsUseCase;
+
+    @Inject
+    CreateAccountUseCase createAccountUseCase;
+
+    @Inject
+    PostLedgerTransactionUseCase postLedgerTransactionUseCase;
+
+    @Tag("integration-test")
+    @Test
+    void shouldCreateWalletAccountsAndTransfer() {
+        var walletA = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-a", "BRL", "Wallet A")
+        );
+        var walletB = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-b", "BRL", "Wallet B")
+        );
+
+        var funding = createAccountUseCase.execute(
+                new CreateAccountCommand(DEFAULT_TENANT, "Funding", AccountType.ASSET, "BRL", true)
+        );
+
+        postLedgerTransactionUseCase.execute(new PostLedgerTransactionCommand(
+                DEFAULT_TENANT,
+                "fund-wallet-a",
+                "fund-wallet-a",
+                "Funding A",
+                Instant.now(),
+                java.util.List.of(
+                        new PostingEntryCommand(funding.getId(), EntryDirection.DEBIT, 10000, "BRL"),
+                        new PostingEntryCommand(walletA.getLedgerAccountId(), EntryDirection.CREDIT, 10000, "BRL")
+                )
+        ));
+
+        transferBetweenWalletAccountsUseCase.execute(
+                DEFAULT_TENANT,
+                new TransferBetweenWalletAccountsCommand(
+                        "transfer-1",
+                        walletA.getId(),
+                        walletB.getId(),
+                        5000,
+                        "BRL",
+                        "Wallet transfer"
+                )
+        );
+
+        var balanceA = getWalletBalanceUseCase.execute(DEFAULT_TENANT, walletA.getId());
+        var balanceB = getWalletBalanceUseCase.execute(DEFAULT_TENANT, walletB.getId());
+
+        assertEquals(5000L, balanceA.getBalanceMinor());
+        assertEquals(5000L, balanceB.getBalanceMinor());
+    }
+
+    @Tag("integration-test")
+    @Test
+    void shouldAllowInternalOwnerTypeForFundingWalletTransfers() {
+        var fundingWallet = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.INTERNAL, "funding", "BRL", "Funding Wallet")
+        );
+        var customerWallet = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-1", "BRL", "Customer Wallet")
+        );
+
+        var fundingAccount = createAccountUseCase.execute(
+                new CreateAccountCommand(DEFAULT_TENANT, "Funding", AccountType.ASSET, "BRL", true)
+        );
+
+        postLedgerTransactionUseCase.execute(new PostLedgerTransactionCommand(
+                DEFAULT_TENANT,
+                "fund-internal-wallet",
+                "fund-internal-wallet",
+                "Fund internal wallet",
+                Instant.now(),
+                java.util.List.of(
+                        new PostingEntryCommand(fundingAccount.getId(), EntryDirection.DEBIT, 20000, "BRL"),
+                        new PostingEntryCommand(fundingWallet.getLedgerAccountId(), EntryDirection.CREDIT, 20000, "BRL")
+                )
+        ));
+
+        transferBetweenWalletAccountsUseCase.execute(
+                DEFAULT_TENANT,
+                new TransferBetweenWalletAccountsCommand(
+                        "internal-to-customer-1",
+                        fundingWallet.getId(),
+                        customerWallet.getId(),
+                        7000,
+                        "BRL",
+                        "Funding via internal wallet"
+                )
+        );
+
+        var fundingBalance = getWalletBalanceUseCase.execute(DEFAULT_TENANT, fundingWallet.getId());
+        var customerBalance = getWalletBalanceUseCase.execute(DEFAULT_TENANT, customerWallet.getId());
+
+        assertEquals(13000L, fundingBalance.getBalanceMinor());
+        assertEquals(7000L, customerBalance.getBalanceMinor());
+    }
+
+    @Tag("integration-test")
+    @Test
+    void shouldAllowSameOwnerAcrossTenants() throws Exception {
+        UUID tenantB = UUID.randomUUID();
+        insertTenant(tenantB, "Tenant B");
+
+        var walletDefault = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-1", "BRL", "Default Wallet")
+        );
+
+        var walletOther = createWalletAccountUseCase.execute(
+                tenantB,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-1", "BRL", "Other Wallet")
+        );
+
+        assertNotEquals(walletDefault.getId(), walletOther.getId());
+    }
+
+    private void insertTenant(UUID tenantId, String name) throws Exception {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     "INSERT INTO tenants (id, name, status, created_at) VALUES (?, ?, 'ACTIVE', CURRENT_TIMESTAMP)"
+             )) {
+            ps.setObject(1, tenantId);
+            ps.setString(2, name);
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -14,3 +14,4 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.swagger-ui.enable=true
 quarkus.smallrye-openapi.path=/openapi
 quarkus.flyway.migrate-at-start=true
+wallet.api-keys=


### PR DESCRIPTION
Summary: Implements Phase 1 Wallet/Ledger behavior for funding flows by allowing INTERNAL wallet accounts to run negative balances in the Ledger, while preserving the wallet‑over‑ledger model and transfer rules from the spec.
Changes:

- Aligns WalletAccount → LedgerAccount creation with spec: allowNegative=false by default, and allowNegative=true for INTERNAL funding accounts (RF‑01, LedgerAccount).

- Keeps transfers as Ledger transactions (debit/credit) per RF‑04 and the “Wallet never changes balance directly” rule.

- Allows INTERNAL wallet accounts to transfer without positive balance (funding use case).

- Adds integration test covering INTERNAL funding and transfer flow.

- Adds minimal System.out logs around transfer validation and ledger failures (in line with “logs with tenantId + idempotencyKey”; currently logs idempotencyKey).
