### PR TITLE
Configure Quarkus coverage and clean test warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,11 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.3.1</quarkus.platform.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencyManagement>
@@ -24,6 +27,11 @@
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>2.1.214</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -40,6 +48,18 @@
             <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-swagger-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
             <version>2.4.0</version>
@@ -52,6 +72,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jacoco</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Dependência para usar @InjectMock -->

--- a/src/main/java/com/sistema/creditcard/infraestrutura/mapper/TransacaoMapper.java
+++ b/src/main/java/com/sistema/creditcard/infraestrutura/mapper/TransacaoMapper.java
@@ -11,14 +11,17 @@ public interface TransacaoMapper {
 
     @Mapping(target = "cartao.id", source = "cartao.id")
     @Mapping(target = "fatura", ignore = true)
+    @Mapping(target = "id", source = "id")
     TransacaoEntity toEntity(Transacao transacao);
 
     @Mapping(target = "cartao.id", source = "cartao.id")
     @Mapping(target = "fatura", ignore = true)
+    @Mapping(target = "id", source = "id")
     Transacao toDomain(TransacaoEntity transacaoEntityEntity);
 
     @Mapping(target = "cartao.id", source = "cartaoId")
     @Mapping(target = "fatura", ignore = true)
+    @Mapping(target = "id", ignore = true)
     Transacao toDomain(TransacaoDTO transacaoDTO);
 
     @Mapping(target = "cartaoId", source = "cartao.id")

--- a/src/main/java/com/sistema/customer/infraestrutura/mapper/CustomerMapper.java
+++ b/src/main/java/com/sistema/customer/infraestrutura/mapper/CustomerMapper.java
@@ -40,7 +40,10 @@ public interface CustomerMapper {
             @Mapping(target = "cpf", source = "cpf"),
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "email", source = "email"),
-            @Mapping(target = "phoneNumber", source = "phoneNumber")
+            @Mapping(target = "phoneNumber", source = "phoneNumber"),
+            @Mapping(target = "cnpj", ignore = true),
+            @Mapping(target = "ativo", ignore = true),
+            @Mapping(target = "dataCadastro", ignore = true)
     })
     Customer toDomain(CustomerDTO customerDTO);
 }

--- a/src/test/java/com/sistema/creditcard/dominio/servico/FaturaServiceTest.java
+++ b/src/test/java/com/sistema/creditcard/dominio/servico/FaturaServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -40,7 +41,7 @@ public class FaturaServiceTest {
 
         // Assert: Verifica se o total e o pagamento mínimos foram calculadores corretamente
         BigDecimal totalEsperado = new BigDecimal("150.00");
-        BigDecimal pagamentoMinimoEsperado = totalEsperado.multiply(new BigDecimal("0.15")).setScale(2, BigDecimal.ROUND_HALF_UP);
+        BigDecimal pagamentoMinimoEsperado = totalEsperado.multiply(new BigDecimal("0.15")).setScale(2, RoundingMode.HALF_UP);
 
         assertEquals(totalEsperado, fatura.getTotal(), "o total deve ser 150.00");
         assertEquals(pagamentoMinimoEsperado, fatura.getPagamentoMinimo(), "o pagamento mínimo deve ser 22.50");

--- a/src/test/java/com/sistema/infraestrutura/repositorio/DbCleanIT.java
+++ b/src/test/java/com/sistema/infraestrutura/repositorio/DbCleanIT.java
@@ -29,12 +29,13 @@ public abstract class DbCleanIT {
                     "SELECT TABLE_NAME " +
                             "FROM INFORMATION_SCHEMA.TABLES " +
                             "WHERE TABLE_SCHEMA='PUBLIC' AND TABLE_TYPE='BASE TABLE'")) {
-                while (rs.next()) tables.add(rs.getString(1));
-            }
+            while (rs.next()) tables.add(rs.getString(1));
+        }
 
-            for (String table : tables) {
-                st.executeUpdate("TRUNCATE TABLE " + table);
-            }
+        for (String table : tables) {
+            String quotedTable = "\"" + table.replace("\"", "\"\"") + "\"";
+            st.executeUpdate("TRUNCATE TABLE " + quotedTable);
+        }
 
             st.execute("SET REFERENTIAL_INTEGRITY TRUE");
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,3 @@
-# Ativar console do H2 e definir o caminho
-quarkus.h2.console.enable=true
-quarkus.h2.console.path=/h2-console
-
 quarkus.http.port=8080
 quarkus.datasource.db-kind=h2
 #quarkus.datasource.jdbc.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
@@ -15,3 +11,7 @@ quarkus.swagger-ui.enable=true
 quarkus.smallrye-openapi.path=/openapi
 quarkus.flyway.migrate-at-start=true
 wallet.api-keys=
+
+# Quarkus JaCoCo coverage
+quarkus.jacoco.report=true
+quarkus.jacoco.report-location=target/site/jacoco


### PR DESCRIPTION
Summary:

Switch coverage reporting to Quarkus JaCoCo and clean up test/build warnings.

Changes:

- Add Quarkus extensions for OpenAPI/Swagger UI/Flyway and configure Quarkus JaCoCo report output.

- Set Maven source/report encoding and use compiler release=17.

- Override H2 to 2.1.214 for Flyway compatibility.

- Fix MapStruct mappings for Transacao and Customer to eliminate unmapped warnings.

- Quote table names during test DB cleanup to handle case‑sensitive tables.

- Replace deprecated BigDecimal.ROUND_HALF_UP with RoundingMode.HALF_UP.