### PR TITLE
feat(wallet): standardize errors and validation

### DIFF
--- a/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
+++ b/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
@@ -1,0 +1,200 @@
+# ADR — Erros Padronizados e Validação Declarativa na Wallet API
+
+- **Status:** Accepted
+- **Data:** 2026-01-25
+- **Contexto:** Wallet API (Fase 1) sobre Ledger Core
+
+---
+
+## Contexto
+
+Durante testes do MVP da Wallet, ocorreram respostas **400 genéricas** (ex.: “Solicitação Inválida”) quando o payload possuía valores inválidos (ex.: `ownerType` diferente de `CUSTOMER`). Isso dificulta o uso por clientes externos, aumenta tempo de integração e gera suporte desnecessário.
+
+O comportamento atual usa `try/catch` de `IllegalArgumentException` no resource e retorna `WebApplicationException` sem um contrato de erro consistente.
+
+A especificação do MVP introduziu o requisito **RF-06 — Modelo de Erro (Developer-friendly)**, recomendando um formato estruturado baseado em **Problem Details (RFC 7807)** com `errorCode`, `violations[]` e `traceId`.
+
+---
+
+## Decisão
+
+Adotar na Wallet API:
+
+1) **Validação declarativa (Bean Validation)** nos DTOs de request (ex.: `CreateWalletAccountRequest`, `CreateTransferRequest`).
+
+2) **Erros padronizados** no formato **Problem Details** (RFC 7807 ou equivalente), contendo:
+- `type`, `title`, `status`, `detail`, `instance`
+- `errorCode`
+- `violations[]` (quando aplicável)
+- `traceId`
+
+3) **Exception Mappers (JAX-RS)** para transformar exceções em respostas consistentes:
+- validação de payload → 400 com `violations`
+- conflitos de negócio (ex.: conta já existe) → 409
+- não encontrado → 404
+- não autorizado (API key inválida) → 401
+
+4) **Correlações de requisição**: gerar/propagar `traceId` e incluir em logs + resposta.
+
+---
+
+## Motivações
+
+- Melhorar DX (Developer Experience) e reduzir fricção de integração
+- Tornar o MVP vendável (API autoexplicativa)
+- Evitar “debug lendo código” em situações comuns
+- Padronizar o tratamento de erros desde o início
+
+---
+
+## Alternativas consideradas
+
+### A) Manter `try/catch` no resource com mensagens simples
+- **Prós:** rápido
+- **Contras:** inconsistência, difícil padronizar, não escala
+
+### B) Retornar apenas mensagens de texto
+- **Prós:** simples
+- **Contras:** não suporta erros por campo e automação do cliente
+
+### C) Expor o ledger para debug
+- **Prós:** facilita testes internos
+- **Contras:** quebra encapsulamento e segurança do produto
+
+---
+
+## Consequências
+
+### Positivas
+- Contrato claro para clientes externos
+- Redução de suporte e tempo de integração
+- Melhor observabilidade com `traceId`
+
+### Negativas / Custos
+- Implementar DTO validations + exception mappers
+- Manter catálogo de `errorCode`
+
+---
+
+## Especificação de Implementação (para Codex)
+
+### Objetivo
+Implementar validação declarativa e erros padronizados no **módulo Wallet**, atendendo o requisito **RF-06** do documento “Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)”.
+
+### Escopo
+Aplicar em endpoints:
+- `POST /accounts`
+- `GET /accounts/{id}/balance`
+- `GET /accounts/{id}/statement`
+- `POST /transfers`
+
+### Regras de contrato de erro
+Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Details + extensões):
+
+```json
+{
+  "type": "https://errors.yourdomain.com/<category>",
+  "title": "<short title>",
+  "status": 400,
+  "detail": "<human readable>",
+  "instance": "/<path>",
+  "errorCode": "<STABLE_CODE>",
+  "violations": [
+    {"field": "<field>", "message": "<message>", "rejectedValue": "<value>"}
+  ],
+  "traceId": "<request-id>"
+}
+```
+
+- `violations` é obrigatório apenas para erros de validação.
+- `traceId` deve sempre existir.
+
+### Mapeamento de erros
+
+#### 400 — Validation error
+- Quando Bean Validation falhar (ex.: `ConstraintViolationException`, `ResteasyReactiveViolationException`)
+- `errorCode = WALLET_VALIDATION_ERROR`
+- Preencher `violations[]`
+
+Casos mínimos:
+- `ownerType` inválido → mensagem deve listar valores permitidos (`CUSTOMER`, `INTERNAL`)
+- `ownerId` vazio
+- `currency` inválida
+
+#### 401 — Unauthorized
+- API key ausente/inválida
+- `errorCode = WALLET_UNAUTHORIZED`
+
+#### 404 — Not Found
+- WalletAccount não encontrada (no tenant)
+- `errorCode = WALLET_ACCOUNT_NOT_FOUND`
+
+#### 409 — Conflict
+- Conta já existe (unicidade)
+- `errorCode = WALLET_ACCOUNT_ALREADY_EXISTS`
+
+#### 500 — Unexpected
+- Qualquer exceção não mapeada
+- `errorCode = WALLET_INTERNAL_ERROR`
+
+### DTOs: adicionar Bean Validation
+
+#### CreateWalletAccountRequest
+- `ownerType`: `@NotBlank` + validação de enum (CUSTOMER/INTERNAL)
+- `ownerId`: `@NotBlank`
+- `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
+- `label`: opcional
+
+#### CreateTransferRequest
+- `idempotencyKey`: `@NotBlank`
+- `fromAccountId`: `@NotBlank` + UUID format validation
+- `toAccountId`: `@NotBlank` + UUID format validation
+- `amountMinor`: `@Positive`
+- `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
+
+### Enum parsing (evitar valueOf direto)
+- Implementar um `@ValidEnum` custom annotation OU um `ParamConverter`/`JsonbAdapter` para mapear string → enum com erro amigável.
+- Se `ownerType` for inválido, retornar 400 com `violations` e valores permitidos.
+
+### Exception Mappers
+Implementar `@Provider` mappers:
+
+1) `ValidationExceptionMapper`
+- Converte violations em lista ordenada por campo
+
+2) `WebApplicationExceptionMapper` (ou específico)
+- Padroniza respostas para 401/404/409 lançadas pela aplicação
+
+3) `ThrowableMapper`
+- Fallback 500 com `traceId`
+
+### TraceId / Correlation
+- Se request tiver header `X-Request-Id`, reutilizar
+- Senão gerar UUID
+- Incluir `traceId` na resposta e log
+- Ideal: `ContainerRequestFilter` + `ContainerResponseFilter`
+
+### Refatoração do resource
+- Remover `try/catch IllegalArgumentException` do resource
+- Deixar o resource “fino”, delegando validação ao Bean Validation e regras ao use case
+
+### Testes de integração (mínimos)
+Criar testes que validem payload e formato de erro:
+- `POST /accounts` com `ownerType=FUNDER` → 400 + violations contendo ownerType
+- `POST /accounts` sem `ownerId` → 400 + violations
+- `POST /accounts` duplicado → 409 + errorCode
+- API key ausente → 401 + errorCode
+
+### Definition of Done
+- Todas as rotas retornam erros no mesmo formato
+- `traceId` presente sempre
+- Sem mensagens genéricas sem detalhe
+- Testes cobrindo os principais cenários
+
+---
+
+## Notas
+
+- O domínio do Ledger não deve ser exposto em erros (sem IDs/entidades internas além do necessário).
+- Preferir mensagens úteis, mas não vazar detalhes sensíveis (ex.: stacktrace).
+

--- a/docs/guidelines_projeto.md
+++ b/docs/guidelines_projeto.md
@@ -30,6 +30,9 @@ Pacotes principais:
 - Camada de produto sobre o Ledger.
 - Resolvendo tenant via API key (header `X-API-Key`).
 - Operacoes principais: criar conta, saldo, extrato, transferencia.
+- Erros padronizados no formato Problem Details (RFC 7807 + extensoes).
+- Validacao declarativa via Bean Validation nos DTOs.
+- `traceId` sempre presente nas respostas; reutiliza `X-Request-Id` quando enviado.
 
 ## Regras tecnicas importantes
 - **Saldo negativo**: respeitar `allowNegative`.
@@ -39,7 +42,23 @@ Pacotes principais:
   - 400 para validacoes
   - 401 para API key invalida
   - 404 para entidades nao encontradas
-  - 409 para conflitos de idempotencia/duplicidade
+  - 409 para conflitos de idempotencia/duplicidade e regras de negocio (ex.: saldo insuficiente)
+
+## Padrao de erros (Problem Details)
+- Respostas de erro devem seguir o contrato:
+  - `type`, `title`, `status`, `detail`, `instance`
+  - `errorCode` estavel por modulo
+  - `violations[]` para erros de validacao
+  - `traceId` sempre presente
+- Preferir excecoes tipadas no Application para erros de negocio.
+
+## Reuso entre modulos (Wallet/Ledger/CreditCard)
+- Separar componentes genericos (ErrorResponse, traceId filter, mappers base) em um pacote comum.
+- Cada modulo define:
+  - catalogo de `errorCode`
+  - excecoes tipadas do dominio
+  - resolver de `type/title` se necessario
+- Objetivo: padrao uniforme com minima duplicacao.
 
 ## Testes
 - JUnit 5 + QuarkusTest.

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/sistema/wallet/api/WalletTransferResource.java
+++ b/src/main/java/com/sistema/wallet/api/WalletTransferResource.java
@@ -6,12 +6,12 @@ import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
 import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
 import com.sistema.wallet.application.tenant.TenantResolver;
 import jakarta.inject.Inject;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -28,35 +28,25 @@ public class WalletTransferResource {
     TransferBetweenWalletAccountsUseCase transferBetweenWalletAccountsUseCase;
 
     @POST
-    public Response transfer(@HeaderParam("X-API-Key") String apiKey, TransferRequest request) {
+    public Response transfer(@HeaderParam("X-API-Key") String apiKey,
+                             @Valid TransferRequest request) {
         UUID tenantId = requireTenantId(apiKey);
-        try {
-            TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
-                    request.getIdempotencyKey(),
-                    UUID.fromString(request.getFromAccountId()),
-                    UUID.fromString(request.getToAccountId()),
-                    request.getAmountMinor(),
-                    request.getCurrency(),
-                    request.getDescription()
-            );
-            var result = transferBetweenWalletAccountsUseCase.execute(tenantId, command);
-            TransferResponse response = new TransferResponse();
-            response.setTransactionId(result.getTransactionId().toString());
-            response.setStatus(result.getStatus());
-            return Response.status(Response.Status.CREATED).entity(response).build();
-        } catch (IllegalArgumentException ex) {
-            if (ex.getMessage() != null && ex.getMessage().startsWith("wallet account not found")) {
-                throw new WebApplicationException(ex.getMessage(), Response.Status.NOT_FOUND);
-            }
-            throw new WebApplicationException(ex.getMessage(), Response.Status.BAD_REQUEST);
-        }
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                request.getIdempotencyKey(),
+                UUID.fromString(request.getFromAccountId()),
+                UUID.fromString(request.getToAccountId()),
+                request.getAmountMinor(),
+                request.getCurrency(),
+                request.getDescription()
+        );
+        var result = transferBetweenWalletAccountsUseCase.execute(tenantId, command);
+        TransferResponse response = new TransferResponse();
+        response.setTransactionId(result.getTransactionId().toString());
+        response.setStatus(result.getStatus());
+        return Response.status(Response.Status.CREATED).entity(response).build();
     }
 
     private UUID requireTenantId(String apiKey) {
-        try {
-            return tenantResolver.resolveTenantId(apiKey);
-        } catch (IllegalArgumentException ex) {
-            throw new WebApplicationException(ex.getMessage(), Response.Status.UNAUTHORIZED);
-        }
+        return tenantResolver.resolveTenantId(apiKey);
     }
 }

--- a/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
@@ -1,9 +1,22 @@
 package com.sistema.wallet.api.dto;
 
+import com.sistema.wallet.api.validation.ValidEnum;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public class CreateWalletAccountRequest {
+    @NotBlank(message = "ownerType is required")
+    @ValidEnum(enumClass = WalletOwnerType.class, message = "ownerType must be one of: CUSTOMER, INTERNAL")
     private String ownerType;
+
+    @NotBlank(message = "ownerId is required")
     private String ownerId;
+
+    @NotBlank(message = "currency is required")
+    @Pattern(regexp = "^[A-Z]{3}$", message = "currency must be a 3-letter ISO code")
     private String currency;
+
     private String label;
 
     public String getOwnerType() {

--- a/src/main/java/com/sistema/wallet/api/dto/TransferRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/TransferRequest.java
@@ -1,11 +1,30 @@
 package com.sistema.wallet.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
 public class TransferRequest {
+    @NotBlank(message = "idempotencyKey is required")
     private String idempotencyKey;
+
+    @NotBlank(message = "fromAccountId is required")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            message = "fromAccountId must be a valid UUID")
     private String fromAccountId;
+
+    @NotBlank(message = "toAccountId is required")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            message = "toAccountId must be a valid UUID")
     private String toAccountId;
+
+    @Positive(message = "amountMinor must be greater than zero")
     private long amountMinor;
+
+    @NotBlank(message = "currency is required")
+    @Pattern(regexp = "^[A-Z]{3}$", message = "currency must be a 3-letter ISO code")
     private String currency;
+
     private String description;
 
     public String getIdempotencyKey() {

--- a/src/main/java/com/sistema/wallet/api/error/ErrorResponse.java
+++ b/src/main/java/com/sistema/wallet/api/error/ErrorResponse.java
@@ -1,0 +1,82 @@
+package com.sistema.wallet.api.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+    private String type;
+    private String title;
+    private Integer status;
+    private String detail;
+    private String instance;
+    private String errorCode;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<ErrorViolation> violations;
+    private String traceId;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public List<ErrorViolation> getViolations() {
+        return violations;
+    }
+
+    public void setViolations(List<ErrorViolation> violations) {
+        this.violations = violations;
+    }
+
+    public String getTraceId() {
+        return traceId;
+    }
+
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/ErrorResponseFactory.java
+++ b/src/main/java/com/sistema/wallet/api/error/ErrorResponseFactory.java
@@ -1,0 +1,38 @@
+package com.sistema.wallet.api.error;
+
+import com.sistema.wallet.api.trace.TraceIdProvider;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.List;
+
+public final class ErrorResponseFactory {
+    private ErrorResponseFactory() {
+    }
+
+    public static ErrorResponse build(String type,
+                                      String title,
+                                      int status,
+                                      String detail,
+                                      String instance,
+                                      String errorCode,
+                                      List<ErrorViolation> violations,
+                                      TraceIdProvider traceIdProvider) {
+        ErrorResponse response = new ErrorResponse();
+        response.setType(type);
+        response.setTitle(title);
+        response.setStatus(status);
+        response.setDetail(detail);
+        response.setInstance(instance);
+        response.setErrorCode(errorCode);
+        response.setViolations(violations);
+        response.setTraceId(traceIdProvider.getTraceId());
+        return response;
+    }
+
+    public static String resolveInstance(UriInfo uriInfo) {
+        if (uriInfo == null || uriInfo.getRequestUri() == null) {
+            return null;
+        }
+        return uriInfo.getRequestUri().getPath();
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/ErrorViolation.java
+++ b/src/main/java/com/sistema/wallet/api/error/ErrorViolation.java
@@ -1,0 +1,43 @@
+package com.sistema.wallet.api.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorViolation {
+    private String field;
+    private String message;
+    private Object rejectedValue;
+
+    public ErrorViolation() {
+    }
+
+    public ErrorViolation(String field, String message, Object rejectedValue) {
+        this.field = field;
+        this.message = message;
+        this.rejectedValue = rejectedValue;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Object getRejectedValue() {
+        return rejectedValue;
+    }
+
+    public void setRejectedValue(Object rejectedValue) {
+        this.rejectedValue = rejectedValue;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
@@ -1,0 +1,13 @@
+package com.sistema.wallet.api.error;
+
+public final class WalletErrorCodes {
+    public static final String WALLET_VALIDATION_ERROR = "WALLET_VALIDATION_ERROR";
+    public static final String WALLET_UNAUTHORIZED = "WALLET_UNAUTHORIZED";
+    public static final String WALLET_ACCOUNT_NOT_FOUND = "WALLET_ACCOUNT_NOT_FOUND";
+    public static final String WALLET_ACCOUNT_ALREADY_EXISTS = "WALLET_ACCOUNT_ALREADY_EXISTS";
+    public static final String WALLET_INSUFFICIENT_BALANCE = "WALLET_INSUFFICIENT_BALANCE";
+    public static final String WALLET_INTERNAL_ERROR = "WALLET_INTERNAL_ERROR";
+
+    private WalletErrorCodes() {
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletErrorTypes.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletErrorTypes.java
@@ -1,0 +1,12 @@
+package com.sistema.wallet.api.error;
+
+public final class WalletErrorTypes {
+    public static final String VALIDATION = "https://errors.yourdomain.com/validation";
+    public static final String UNAUTHORIZED = "https://errors.yourdomain.com/unauthorized";
+    public static final String NOT_FOUND = "https://errors.yourdomain.com/not-found";
+    public static final String CONFLICT = "https://errors.yourdomain.com/conflict";
+    public static final String INTERNAL = "https://errors.yourdomain.com/internal";
+
+    private WalletErrorTypes() {
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletExceptionMapper.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletExceptionMapper.java
@@ -1,0 +1,55 @@
+package com.sistema.wallet.api.error;
+
+import com.sistema.wallet.api.trace.TraceIdProvider;
+import com.sistema.wallet.application.exception.WalletException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class WalletExceptionMapper implements ExceptionMapper<WalletException> {
+    @Context
+    UriInfo uriInfo;
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public Response toResponse(WalletException exception) {
+        int status = exception.getStatus();
+        String type = mapType(status);
+        String title = mapTitle(status);
+        ErrorResponse response = ErrorResponseFactory.build(
+                type,
+                title,
+                status,
+                exception.getMessage(),
+                ErrorResponseFactory.resolveInstance(uriInfo),
+                exception.getErrorCode(),
+                null,
+                traceIdProvider
+        );
+        return Response.status(status).entity(response).build();
+    }
+
+    private String mapType(int status) {
+        return switch (status) {
+            case 401 -> WalletErrorTypes.UNAUTHORIZED;
+            case 404 -> WalletErrorTypes.NOT_FOUND;
+            case 409 -> WalletErrorTypes.CONFLICT;
+            default -> WalletErrorTypes.INTERNAL;
+        };
+    }
+
+    private String mapTitle(int status) {
+        return switch (status) {
+            case 401 -> "Unauthorized";
+            case 404 -> "Not found";
+            case 409 -> "Conflict";
+            default -> "Error";
+        };
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletIllegalArgumentExceptionMapper.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletIllegalArgumentExceptionMapper.java
@@ -1,0 +1,33 @@
+package com.sistema.wallet.api.error;
+
+import com.sistema.wallet.api.trace.TraceIdProvider;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class WalletIllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    @Context
+    UriInfo uriInfo;
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public Response toResponse(IllegalArgumentException exception) {
+        ErrorResponse response = ErrorResponseFactory.build(
+                WalletErrorTypes.VALIDATION,
+                "Validation error",
+                400,
+                exception.getMessage(),
+                ErrorResponseFactory.resolveInstance(uriInfo),
+                WalletErrorCodes.WALLET_VALIDATION_ERROR,
+                null,
+                traceIdProvider
+        );
+        return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletThrowableMapper.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletThrowableMapper.java
@@ -1,0 +1,38 @@
+package com.sistema.wallet.api.error;
+
+import com.sistema.wallet.api.trace.TraceIdProvider;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+@Provider
+public class WalletThrowableMapper implements ExceptionMapper<Throwable> {
+    private static final Logger LOG = Logger.getLogger(WalletThrowableMapper.class);
+
+    @Context
+    UriInfo uriInfo;
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public Response toResponse(Throwable exception) {
+        String traceId = traceIdProvider.getTraceId();
+        LOG.errorf(exception, "wallet unhandled error traceId=%s", traceId);
+        ErrorResponse response = ErrorResponseFactory.build(
+                WalletErrorTypes.INTERNAL,
+                "Internal server error",
+                500,
+                "Unexpected error",
+                ErrorResponseFactory.resolveInstance(uriInfo),
+                WalletErrorCodes.WALLET_INTERNAL_ERROR,
+                null,
+                traceIdProvider
+        );
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(response).build();
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletValidationExceptionMapper.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletValidationExceptionMapper.java
@@ -1,0 +1,64 @@
+package com.sistema.wallet.api.error;
+
+import com.sistema.wallet.api.trace.TraceIdProvider;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Provider
+public class WalletValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+    @Context
+    UriInfo uriInfo;
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        List<ErrorViolation> violations = exception.getConstraintViolations()
+                .stream()
+                .map(this::toViolation)
+                .sorted(Comparator.comparing(ErrorViolation::getField, Comparator.nullsLast(String::compareTo)))
+                .collect(Collectors.toList());
+
+        ErrorResponse response = ErrorResponseFactory.build(
+                WalletErrorTypes.VALIDATION,
+                "Validation error",
+                400,
+                "Validation failed",
+                ErrorResponseFactory.resolveInstance(uriInfo),
+                WalletErrorCodes.WALLET_VALIDATION_ERROR,
+                violations,
+                traceIdProvider
+        );
+
+        return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+    }
+
+    private ErrorViolation toViolation(ConstraintViolation<?> violation) {
+        String field = extractField(violation);
+        Object rejected = violation.getInvalidValue();
+        return new ErrorViolation(field, violation.getMessage(), rejected);
+    }
+
+    private String extractField(ConstraintViolation<?> violation) {
+        if (violation.getPropertyPath() == null) {
+            return null;
+        }
+        String path = violation.getPropertyPath().toString();
+        int lastDot = path.lastIndexOf('.');
+        if (lastDot >= 0 && lastDot + 1 < path.length()) {
+            return path.substring(lastDot + 1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/trace/RequestTraceFilter.java
+++ b/src/main/java/com/sistema/wallet/api/trace/RequestTraceFilter.java
@@ -1,0 +1,44 @@
+package com.sistema.wallet.api.trace;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+import java.util.UUID;
+
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class RequestTraceFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    public static final String TRACE_ID_HEADER = "X-Request-Id";
+    private static final String TRACE_ID_PROPERTY = "traceId";
+    private static final Logger LOG = Logger.getLogger(RequestTraceFilter.class);
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String traceId = requestContext.getHeaderString(TRACE_ID_HEADER);
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString();
+        }
+        traceIdProvider.setTraceId(traceId);
+        requestContext.setProperty(TRACE_ID_PROPERTY, traceId);
+        LOG.debugf("wallet request traceId=%s path=%s", traceId, requestContext.getUriInfo().getPath());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        Object traceId = requestContext.getProperty(TRACE_ID_PROPERTY);
+        if (traceId == null) {
+            traceId = traceIdProvider.getTraceId();
+        }
+        responseContext.getHeaders().putSingle(TRACE_ID_HEADER, traceId.toString());
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/trace/TraceIdProvider.java
+++ b/src/main/java/com/sistema/wallet/api/trace/TraceIdProvider.java
@@ -1,0 +1,21 @@
+package com.sistema.wallet.api.trace;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import java.util.UUID;
+
+@RequestScoped
+public class TraceIdProvider {
+    private String traceId;
+
+    public String getTraceId() {
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString();
+        }
+        return traceId;
+    }
+
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/validation/EnumValidator.java
+++ b/src/main/java/com/sistema/wallet/api/validation/EnumValidator.java
@@ -1,0 +1,27 @@
+package com.sistema.wallet.api.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+    private Set<String> allowed;
+
+    @Override
+    public void initialize(ValidEnum annotation) {
+        allowed = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        return allowed.contains(value);
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/validation/ValidEnum.java
+++ b/src/main/java/com/sistema/wallet/api/validation/ValidEnum.java
@@ -1,0 +1,26 @@
+package com.sistema.wallet.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Constraint(validatedBy = EnumValidator.class)
+@Documented
+public @interface ValidEnum {
+    String message() default "must be one of the allowed values";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+}

--- a/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
@@ -5,6 +5,7 @@ import com.sistema.ledger.application.command.CreateAccountCommand;
 import com.sistema.ledger.domain.model.AccountType;
 import com.sistema.ledger.domain.model.LedgerAccount;
 import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.application.exception.WalletAccountAlreadyExistsException;
 import com.sistema.wallet.domain.model.WalletAccount;
 import com.sistema.wallet.domain.model.WalletAccountStatus;
 import com.sistema.wallet.domain.model.WalletOwnerType;
@@ -38,7 +39,7 @@ public class CreateWalletAccountUseCase {
                 command.getOwnerId(),
                 command.getCurrency()
         ).ifPresent(existing -> {
-            throw new IllegalArgumentException("wallet account already exists");
+            throw new WalletAccountAlreadyExistsException();
         });
 
         String ledgerAccountName = "WalletAccount " + command.getOwnerType() + ":" + command.getOwnerId();

--- a/src/main/java/com/sistema/wallet/application/GetWalletBalanceUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/GetWalletBalanceUseCase.java
@@ -1,6 +1,7 @@
 package com.sistema.wallet.application;
 
 import com.sistema.ledger.application.GetAccountBalanceUseCase;
+import com.sistema.wallet.application.exception.WalletAccountNotFoundException;
 import com.sistema.wallet.application.model.WalletBalance;
 import com.sistema.wallet.domain.model.WalletAccount;
 import com.sistema.wallet.domain.repository.WalletAccountRepository;
@@ -21,7 +22,7 @@ public class GetWalletBalanceUseCase {
 
     public WalletBalance execute(UUID tenantId, UUID accountId) {
         WalletAccount walletAccount = walletAccountRepository.findById(tenantId, accountId)
-                .orElseThrow(() -> new IllegalArgumentException("wallet account not found: " + accountId));
+                .orElseThrow(() -> new WalletAccountNotFoundException(accountId));
         var balance = getAccountBalanceUseCase.execute(tenantId, walletAccount.getLedgerAccountId());
         return new WalletBalance(walletAccount.getId(), balance.getBalanceMinor(), balance.getCurrency());
     }

--- a/src/main/java/com/sistema/wallet/application/GetWalletStatementUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/GetWalletStatementUseCase.java
@@ -1,6 +1,7 @@
 package com.sistema.wallet.application;
 
 import com.sistema.ledger.application.GetAccountStatementUseCase;
+import com.sistema.wallet.application.exception.WalletAccountNotFoundException;
 import com.sistema.wallet.application.model.WalletStatementItem;
 import com.sistema.wallet.application.model.WalletStatementPage;
 import com.sistema.wallet.domain.model.WalletAccount;
@@ -25,7 +26,7 @@ public class GetWalletStatementUseCase {
 
     public WalletStatementPage execute(UUID tenantId, UUID accountId, Instant from, Instant to, int page, int size) {
         WalletAccount walletAccount = walletAccountRepository.findById(tenantId, accountId)
-                .orElseThrow(() -> new IllegalArgumentException("wallet account not found: " + accountId));
+                .orElseThrow(() -> new WalletAccountNotFoundException(accountId));
 
         var statement = getAccountStatementUseCase.execute(
                 tenantId,

--- a/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
@@ -6,6 +6,8 @@ import com.sistema.ledger.application.command.PostLedgerTransactionCommand;
 import com.sistema.ledger.application.command.PostingEntryCommand;
 import com.sistema.ledger.domain.model.EntryDirection;
 import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.exception.WalletAccountNotFoundException;
+import com.sistema.wallet.application.exception.WalletInsufficientBalanceException;
 import com.sistema.wallet.application.model.WalletTransferResult;
 import com.sistema.wallet.domain.model.WalletAccount;
 import com.sistema.wallet.domain.repository.WalletAccountRepository;
@@ -47,12 +49,12 @@ public class TransferBetweenWalletAccountsUseCase {
         WalletAccount fromAccount = walletAccountRepository.findById(tenantId, command.getFromAccountId())
                 .orElseThrow(() -> {
                     System.out.println("TransferBetweenWalletAccounts: fromAccount not found " + command.getFromAccountId());
-                    return new IllegalArgumentException("wallet account not found: " + command.getFromAccountId());
+                    return new WalletAccountNotFoundException(command.getFromAccountId());
                 });
         WalletAccount toAccount = walletAccountRepository.findById(tenantId, command.getToAccountId())
                 .orElseThrow(() -> {
                     System.out.println("TransferBetweenWalletAccounts: toAccount not found " + command.getToAccountId());
-                    return new IllegalArgumentException("wallet account not found: " + command.getToAccountId());
+                    return new WalletAccountNotFoundException(command.getToAccountId());
                 });
 
         if (!fromAccount.getCurrency().equals(command.getCurrency())
@@ -67,7 +69,7 @@ public class TransferBetweenWalletAccountsUseCase {
                 && fromBalance.getBalanceMinor() < command.getAmountMinor()) {
             System.out.println("TransferBetweenWalletAccounts: insufficient balance " + fromBalance.getBalanceMinor()
                     + " < " + command.getAmountMinor());
-            throw new IllegalArgumentException("insufficient balance");
+            throw new WalletInsufficientBalanceException("insufficient balance");
         }
 
         PostLedgerTransactionCommand ledgerCommand = new PostLedgerTransactionCommand(

--- a/src/main/java/com/sistema/wallet/application/exception/WalletAccountAlreadyExistsException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletAccountAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+public class WalletAccountAlreadyExistsException extends WalletException {
+    public WalletAccountAlreadyExistsException() {
+        super("wallet account already exists", 409, WalletErrorCodes.WALLET_ACCOUNT_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/exception/WalletAccountNotFoundException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletAccountNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+import java.util.UUID;
+
+public class WalletAccountNotFoundException extends WalletException {
+    public WalletAccountNotFoundException(UUID accountId) {
+        super("wallet account not found: " + accountId, 404, WalletErrorCodes.WALLET_ACCOUNT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/exception/WalletException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletException.java
@@ -1,0 +1,20 @@
+package com.sistema.wallet.application.exception;
+
+public abstract class WalletException extends RuntimeException {
+    private final int status;
+    private final String errorCode;
+
+    protected WalletException(String message, int status, String errorCode) {
+        super(message);
+        this.status = status;
+        this.errorCode = errorCode;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/exception/WalletInsufficientBalanceException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletInsufficientBalanceException.java
@@ -1,0 +1,9 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+public class WalletInsufficientBalanceException extends WalletException {
+    public WalletInsufficientBalanceException(String message) {
+        super(message, 409, WalletErrorCodes.WALLET_INSUFFICIENT_BALANCE);
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/exception/WalletUnauthorizedException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+public class WalletUnauthorizedException extends WalletException {
+    public WalletUnauthorizedException(String message) {
+        super(message, 401, WalletErrorCodes.WALLET_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolver.java
+++ b/src/main/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolver.java
@@ -1,6 +1,7 @@
 package com.sistema.wallet.infra.tenant;
 
 import com.sistema.wallet.application.tenant.TenantResolver;
+import com.sistema.wallet.application.exception.WalletUnauthorizedException;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -39,11 +40,11 @@ public class ApiKeyTenantResolver implements TenantResolver {
     @Override
     public UUID resolveTenantId(String apiKey) {
         if (apiKey == null || apiKey.isBlank()) {
-            throw new IllegalArgumentException("apiKey is required");
+            throw new WalletUnauthorizedException("apiKey is required");
         }
         UUID tenantId = apiKeyToTenant.get(apiKey);
         if (tenantId == null) {
-            throw new IllegalArgumentException("apiKey not recognized");
+            throw new WalletUnauthorizedException("apiKey not recognized");
         }
         return tenantId;
     }

--- a/src/test/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolverTest.java
+++ b/src/test/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolverTest.java
@@ -1,6 +1,7 @@
 package com.sistema.wallet.infra.tenant;
 
 import org.junit.jupiter.api.Test;
+import com.sistema.wallet.application.exception.WalletUnauthorizedException;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -24,13 +25,13 @@ public class ApiKeyTenantResolverTest {
     public void shouldRejectBlankApiKey() {
         ApiKeyTenantResolver resolver = new ApiKeyTenantResolver(Optional.of(""));
 
-        assertThrows(IllegalArgumentException.class, () -> resolver.resolveTenantId(" "));
+        assertThrows(WalletUnauthorizedException.class, () -> resolver.resolveTenantId(" "));
     }
 
     @Test
     public void shouldRejectUnknownApiKey() {
         ApiKeyTenantResolver resolver = new ApiKeyTenantResolver(Optional.of("key-1=" + UUID.randomUUID()));
 
-        assertThrows(IllegalArgumentException.class, () -> resolver.resolveTenantId("missing"));
+        assertThrows(WalletUnauthorizedException.class, () -> resolver.resolveTenantId("missing"));
     }
 }


### PR DESCRIPTION
Summary:

- Standardize Wallet API error responses to Problem Details with traceId and add declarative validation on request DTOs.

- Introduce wallet-specific exceptions and mappers for consistent 4xx/5xx handling, including insufficient balance.

- Update wallet API tests and guidelines to reflect the new error contract.

Changes:

- Added Bean Validation support in pom.xml.

- Added error/trace/validation infrastructure: src/main/java/com/sistema/wallet/api/error/, src/main/java/com/sistema/wallet/api/trace/, src/main/java/com/sistema/wallet/api/validation/.

- Added wallet application exceptions in src/main/java/com/sistema/wallet/application/exception/.

- Updated wallet resources and use cases to use validation + typed exceptions in src/main/java/com/sistema/wallet/api/WalletAccountResource.java, src/main/java/com/sistema/wallet/api/WalletTransferResource.java, src/main/java/com/sistema/wallet/application/*.java, and src/main/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolver.java.

- Updated wallet tests and added insufficient balance API test in src/test/java/com/sistema/wallet/api/ and src/test/java/com/sistema/wallet/infra/tenant/ApiKeyTenantResolverTest.java.

- Updated guidelines in docs/guidelines_projeto.md.

- Added ADR file docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md.