### PR TITLE
chore: set Java 21 toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It also includes a Ledger core (double-entry, idempotent postings) isolated from
 the card domain.
 
 ## Stack
-- Java 17
+- Java 21
 - Quarkus 3.3.1
 - Hibernate ORM + Panache
 - H2 (in-memory)
@@ -15,7 +15,7 @@ the card domain.
 - Maven
 
 ## Requirements
-- Java 17+
+- Java 21+
 - Maven (or use the repo Maven Wrapper)
 
 ## Run (dev)

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
         <quarkus.platform.version>3.3.1</quarkus.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Summary

- Align the build to Java 21 (Maven source/target/release).
- Update docs to reflect the Java 21 requirement.

Changes

- pom.xml: set maven.compiler.source/target/release to 21.
- README.md: stack and requirements updated to Java 21/21+.