### PR TITLE
chore: rename INTERNAL owner type to FUNDING

### DIFF
--- a/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Pattern;
 
 public class CreateWalletAccountRequest {
     @NotBlank(message = "ownerType is required")
-    @ValidEnum(enumClass = WalletOwnerType.class, message = "ownerType must be one of: CUSTOMER, INTERNAL")
+    @ValidEnum(enumClass = WalletOwnerType.class, message = "ownerType must be one of: CUSTOMER, FUNDING")
     private String ownerType;
 
     @NotBlank(message = "ownerId is required")

--- a/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/CreateWalletAccountUseCase.java
@@ -43,7 +43,7 @@ public class CreateWalletAccountUseCase {
         });
 
         String ledgerAccountName = "WalletAccount " + command.getOwnerType() + ":" + command.getOwnerId();
-        boolean allowNegative = command.getOwnerType() == WalletOwnerType.INTERNAL;
+        boolean allowNegative = command.getOwnerType() == WalletOwnerType.FUNDING;
         LedgerAccount ledgerAccount = createAccountUseCase.execute(
                 new CreateAccountCommand(
                         tenantId,

--- a/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
+++ b/src/main/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCase.java
@@ -65,7 +65,7 @@ public class TransferBetweenWalletAccountsUseCase {
         }
 
         var fromBalance = getAccountBalanceUseCase.execute(tenantId, fromAccount.getLedgerAccountId());
-        if (fromAccount.getOwnerType() != com.sistema.wallet.domain.model.WalletOwnerType.INTERNAL
+        if (fromAccount.getOwnerType() != com.sistema.wallet.domain.model.WalletOwnerType.FUNDING
                 && fromBalance.getBalanceMinor() < command.getAmountMinor()) {
             System.out.println("TransferBetweenWalletAccounts: insufficient balance " + fromBalance.getBalanceMinor()
                     + " < " + command.getAmountMinor());

--- a/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
+++ b/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
@@ -2,5 +2,5 @@ package com.sistema.wallet.domain.model;
 
 public enum WalletOwnerType {
     CUSTOMER,
-    INTERNAL
+    FUNDING
 }

--- a/src/test/java/com/sistema/wallet/infra/WalletIntegrationTest.java
+++ b/src/test/java/com/sistema/wallet/infra/WalletIntegrationTest.java
@@ -100,10 +100,10 @@ class WalletIntegrationTest extends DbCleanIT {
 
     @Tag("integration-test")
     @Test
-    void shouldAllowInternalOwnerTypeForFundingWalletTransfers() {
+    void shouldAllowFundingOwnerTypeForFundingWalletTransfers() {
         var fundingWallet = createWalletAccountUseCase.execute(
                 DEFAULT_TENANT,
-                new CreateWalletAccountCommand(WalletOwnerType.INTERNAL, "funding", "BRL", "Funding Wallet")
+                new CreateWalletAccountCommand(WalletOwnerType.FUNDING, "funding", "BRL", "Funding Wallet")
         );
         var customerWallet = createWalletAccountUseCase.execute(
                 DEFAULT_TENANT,
@@ -116,9 +116,9 @@ class WalletIntegrationTest extends DbCleanIT {
 
         postLedgerTransactionUseCase.execute(new PostLedgerTransactionCommand(
                 DEFAULT_TENANT,
-                "fund-internal-wallet",
-                "fund-internal-wallet",
-                "Fund internal wallet",
+                "fund-funding-wallet",
+                "fund-funding-wallet",
+                "Fund funding wallet",
                 Instant.now(),
                 java.util.List.of(
                         new PostingEntryCommand(fundingAccount.getId(), EntryDirection.DEBIT, 20000, "BRL"),
@@ -129,12 +129,12 @@ class WalletIntegrationTest extends DbCleanIT {
         transferBetweenWalletAccountsUseCase.execute(
                 DEFAULT_TENANT,
                 new TransferBetweenWalletAccountsCommand(
-                        "internal-to-customer-1",
+                        "funding-to-customer-1",
                         fundingWallet.getId(),
                         customerWallet.getId(),
                         7000,
                         "BRL",
-                        "Funding via internal wallet"
+                        "Funding via funding wallet"
                 )
         );
 


### PR DESCRIPTION
Summary

- Rename the wallet owner type from INTERNAL to FUNDING to reflect its funding role, not tenant ownership.

Changes

- WalletOwnerType enum updated to CUSTOMER | FUNDING.

- Wallet account creation validation now accepts FUNDING.

- Funding account rules updated to use the new owner type.

- Wallet integration test updated for FUNDING naming.