### PR TITLE
feat: validate customer on wallet account creation

### DIFF
--- a/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
@@ -5,6 +5,7 @@ public final class WalletErrorCodes {
     public static final String WALLET_UNAUTHORIZED = "WALLET_UNAUTHORIZED";
     public static final String WALLET_ACCOUNT_NOT_FOUND = "WALLET_ACCOUNT_NOT_FOUND";
     public static final String WALLET_ACCOUNT_ALREADY_EXISTS = "WALLET_ACCOUNT_ALREADY_EXISTS";
+    public static final String WALLET_OWNER_NOT_FOUND = "WALLET_OWNER_NOT_FOUND";
     public static final String WALLET_INSUFFICIENT_BALANCE = "WALLET_INSUFFICIENT_BALANCE";
     public static final String WALLET_INTERNAL_ERROR = "WALLET_INTERNAL_ERROR";
 

--- a/src/main/java/com/sistema/wallet/application/exception/WalletOwnerNotFoundException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletOwnerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+public class WalletOwnerNotFoundException extends WalletException {
+    public WalletOwnerNotFoundException(String ownerId) {
+        super("owner not found: " + ownerId, 404, WalletErrorCodes.WALLET_OWNER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Summary

- Validate customer existence when creating a wallet account for ownerType=CUSTOMER.

- Return a wallet-specific 404 error when the referenced customer does not exist.

Changes

- WalletAccountResource now checks customer existence via GetCustomerUseCase and requires UUID ownerId for customer wallets.

- Added WALLET_OWNER_NOT_FOUND error code and WalletOwnerNotFoundException.

- Updated wallet resource tests and added a missing-customer scenario.