### PR TITLE
feat(wallet): return 409 on idempotency replay

### DIFF
--- a/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
+++ b/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
@@ -1,4 +1,4 @@
-# ADR — Erros Padronizados e Validação Declarativa na Wallet API
+﻿# ADR â€” Erros Padronizados e ValidaÃ§Ã£o Declarativa na Wallet API
 
 - **Status:** Accepted
 - **Data:** 2026-01-25
@@ -8,78 +8,78 @@
 
 ## Contexto
 
-Durante testes do MVP da Wallet, ocorreram respostas **400 genéricas** (ex.: “Solicitação Inválida”) quando o payload possuía valores inválidos (ex.: `ownerType` diferente de `CUSTOMER`). Isso dificulta o uso por clientes externos, aumenta tempo de integração e gera suporte desnecessário.
+Durante testes do MVP da Wallet, ocorreram respostas **400 genÃ©ricas** (ex.: â€œSolicitaÃ§Ã£o InvÃ¡lidaâ€) quando o payload possuÃ­a valores invÃ¡lidos (ex.: `ownerType` diferente de `CUSTOMER`). Isso dificulta o uso por clientes externos, aumenta tempo de integraÃ§Ã£o e gera suporte desnecessÃ¡rio.
 
 O comportamento atual usa `try/catch` de `IllegalArgumentException` no resource e retorna `WebApplicationException` sem um contrato de erro consistente.
 
-A especificação do MVP introduziu o requisito **RF-06 — Modelo de Erro (Developer-friendly)**, recomendando um formato estruturado baseado em **Problem Details (RFC 7807)** com `errorCode`, `violations[]` e `traceId`.
+A especificaÃ§Ã£o do MVP introduziu o requisito **RF-06 â€” Modelo de Erro (Developer-friendly)**, recomendando um formato estruturado baseado em **Problem Details (RFC 7807)** com `errorCode`, `violations[]` e `traceId`.
 
 ---
 
-## Decisão
+## DecisÃ£o
 
 Adotar na Wallet API:
 
-1) **Validação declarativa (Bean Validation)** nos DTOs de request (ex.: `CreateWalletAccountRequest`, `CreateTransferRequest`).
+1) **ValidaÃ§Ã£o declarativa (Bean Validation)** nos DTOs de request (ex.: `CreateWalletAccountRequest`, `CreateTransferRequest`).
 
 2) **Erros padronizados** no formato **Problem Details** (RFC 7807 ou equivalente), contendo:
 - `type`, `title`, `status`, `detail`, `instance`
 - `errorCode`
-- `violations[]` (quando aplicável)
+- `violations[]` (quando aplicÃ¡vel)
 - `traceId`
 
-3) **Exception Mappers (JAX-RS)** para transformar exceções em respostas consistentes:
-- validação de payload → 400 com `violations`
-- conflitos de negócio (ex.: conta já existe) → 409
-- não encontrado → 404
-- não autorizado (API key inválida) → 401
+3) **Exception Mappers (JAX-RS)** para transformar exceÃ§Ãµes em respostas consistentes:
+- validaÃ§Ã£o de payload â†’ 400 com `violations`
+- conflitos de negÃ³cio (ex.: conta jÃ¡ existe) â†’ 409
+- nÃ£o encontrado â†’ 404
+- nÃ£o autorizado (API key invÃ¡lida) â†’ 401
 
-4) **Correlações de requisição**: gerar/propagar `traceId` e incluir em logs + resposta.
+4) **CorrelaÃ§Ãµes de requisiÃ§Ã£o**: gerar/propagar `traceId` e incluir em logs + resposta.
 
 ---
 
-## Motivações
+## MotivaÃ§Ãµes
 
-- Melhorar DX (Developer Experience) e reduzir fricção de integração
-- Tornar o MVP vendável (API autoexplicativa)
-- Evitar “debug lendo código” em situações comuns
-- Padronizar o tratamento de erros desde o início
+- Melhorar DX (Developer Experience) e reduzir fricÃ§Ã£o de integraÃ§Ã£o
+- Tornar o MVP vendÃ¡vel (API autoexplicativa)
+- Evitar â€œdebug lendo cÃ³digoâ€ em situaÃ§Ãµes comuns
+- Padronizar o tratamento de erros desde o inÃ­cio
 
 ---
 
 ## Alternativas consideradas
 
 ### A) Manter `try/catch` no resource com mensagens simples
-- **Prós:** rápido
-- **Contras:** inconsistência, difícil padronizar, não escala
+- **PrÃ³s:** rÃ¡pido
+- **Contras:** inconsistÃªncia, difÃ­cil padronizar, nÃ£o escala
 
 ### B) Retornar apenas mensagens de texto
-- **Prós:** simples
-- **Contras:** não suporta erros por campo e automação do cliente
+- **PrÃ³s:** simples
+- **Contras:** nÃ£o suporta erros por campo e automaÃ§Ã£o do cliente
 
 ### C) Expor o ledger para debug
-- **Prós:** facilita testes internos
-- **Contras:** quebra encapsulamento e segurança do produto
+- **PrÃ³s:** facilita testes internos
+- **Contras:** quebra encapsulamento e seguranÃ§a do produto
 
 ---
 
-## Consequências
+## ConsequÃªncias
 
 ### Positivas
 - Contrato claro para clientes externos
-- Redução de suporte e tempo de integração
+- ReduÃ§Ã£o de suporte e tempo de integraÃ§Ã£o
 - Melhor observabilidade com `traceId`
 
 ### Negativas / Custos
 - Implementar DTO validations + exception mappers
-- Manter catálogo de `errorCode`
+- Manter catÃ¡logo de `errorCode`
 
 ---
 
-## Especificação de Implementação (para Codex)
+## EspecificaÃ§Ã£o de ImplementaÃ§Ã£o (para Codex)
 
 ### Objetivo
-Implementar validação declarativa e erros padronizados no **módulo Wallet**, atendendo o requisito **RF-06** do documento “Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)”.
+Implementar validaÃ§Ã£o declarativa e erros padronizados no **mÃ³dulo Wallet**, atendendo o requisito **RF-06** do documento â€œEspecificaÃ§Ã£o â€” Fase 1: Wallet API sobre Ledger (MVP VendÃ¡vel)â€.
 
 ### Escopo
 Aplicar em endpoints:
@@ -89,7 +89,7 @@ Aplicar em endpoints:
 - `POST /transfers`
 
 ### Regras de contrato de erro
-Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Details + extensões):
+Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Details + extensÃµes):
 
 ```json
 {
@@ -106,41 +106,44 @@ Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Detail
 }
 ```
 
-- `violations` é obrigatório apenas para erros de validação.
+- `violations` Ã© obrigatÃ³rio apenas para erros de validaÃ§Ã£o.
 - `traceId` deve sempre existir.
 
 ### Mapeamento de erros
 
-#### 400 — Validation error
+#### 400 â€” Validation error
 - Quando Bean Validation falhar (ex.: `ConstraintViolationException`, `ResteasyReactiveViolationException`)
 - `errorCode = WALLET_VALIDATION_ERROR`
 - Preencher `violations[]`
 
-Casos mínimos:
-- `ownerType` inválido → mensagem deve listar valores permitidos (`CUSTOMER`, `INTERNAL`)
+Casos mÃ­nimos:
+- `ownerType` invÃ¡lido â†’ mensagem deve listar valores permitidos (`CUSTOMER`, `INTERNAL`)
 - `ownerId` vazio
-- `currency` inválida
+- `currency` invÃ¡lida
 
-#### 401 — Unauthorized
-- API key ausente/inválida
+#### 401 â€” Unauthorized
+- API key ausente/invÃ¡lida
 - `errorCode = WALLET_UNAUTHORIZED`
 
-#### 404 — Not Found
-- WalletAccount não encontrada (no tenant)
+#### 404 â€” Not Found
+- WalletAccount nÃ£o encontrada (no tenant)
 - `errorCode = WALLET_ACCOUNT_NOT_FOUND`
 
-#### 409 — Conflict
-- Conta já existe (unicidade)
+#### 409 â€” Conflict
+- Conta jÃ¡ existe (unicidade)
 - `errorCode = WALLET_ACCOUNT_ALREADY_EXISTS`
+- IdempotÃªncia: `idempotencyKey` jÃ¡ usada no mesmo tenant
+- `errorCode = WALLET_IDEMPOTENCY_CONFLICT`
+- Retornar `meta.transactionId` e `meta.idempotencyKey`
 
-#### 500 — Unexpected
-- Qualquer exceção não mapeada
+#### 500 â€” Unexpected
+- Qualquer exceÃ§Ã£o nÃ£o mapeada
 - `errorCode = WALLET_INTERNAL_ERROR`
 
 ### DTOs: adicionar Bean Validation
 
 #### CreateWalletAccountRequest
-- `ownerType`: `@NotBlank` + validação de enum (CUSTOMER/INTERNAL)
+- `ownerType`: `@NotBlank` + validaÃ§Ã£o de enum (CUSTOMER/INTERNAL)
 - `ownerId`: `@NotBlank`
 - `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
 - `label`: opcional
@@ -153,8 +156,8 @@ Casos mínimos:
 - `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
 
 ### Enum parsing (evitar valueOf direto)
-- Implementar um `@ValidEnum` custom annotation OU um `ParamConverter`/`JsonbAdapter` para mapear string → enum com erro amigável.
-- Se `ownerType` for inválido, retornar 400 com `violations` e valores permitidos.
+- Implementar um `@ValidEnum` custom annotation OU um `ParamConverter`/`JsonbAdapter` para mapear string â†’ enum com erro amigÃ¡vel.
+- Se `ownerType` for invÃ¡lido, retornar 400 com `violations` e valores permitidos.
 
 ### Exception Mappers
 Implementar `@Provider` mappers:
@@ -162,39 +165,42 @@ Implementar `@Provider` mappers:
 1) `ValidationExceptionMapper`
 - Converte violations em lista ordenada por campo
 
-2) `WebApplicationExceptionMapper` (ou específico)
-- Padroniza respostas para 401/404/409 lançadas pela aplicação
+2) `WebApplicationExceptionMapper` (ou especÃ­fico)
+- Padroniza respostas para 401/404/409 lanÃ§adas pela aplicaÃ§Ã£o
 
 3) `ThrowableMapper`
 - Fallback 500 com `traceId`
 
 ### TraceId / Correlation
 - Se request tiver header `X-Request-Id`, reutilizar
-- Senão gerar UUID
+- SenÃ£o gerar UUID
 - Incluir `traceId` na resposta e log
 - Ideal: `ContainerRequestFilter` + `ContainerResponseFilter`
 
-### Refatoração do resource
+### RefatoraÃ§Ã£o do resource
 - Remover `try/catch IllegalArgumentException` do resource
-- Deixar o resource “fino”, delegando validação ao Bean Validation e regras ao use case
+- Deixar o resource â€œfinoâ€, delegando validaÃ§Ã£o ao Bean Validation e regras ao use case
 
-### Testes de integração (mínimos)
+### Testes de integraÃ§Ã£o (mÃ­nimos)
 Criar testes que validem payload e formato de erro:
-- `POST /accounts` com `ownerType=FUNDER` → 400 + violations contendo ownerType
-- `POST /accounts` sem `ownerId` → 400 + violations
-- `POST /accounts` duplicado → 409 + errorCode
-- API key ausente → 401 + errorCode
+- `POST /accounts` com `ownerType=FUNDER` â†’ 400 + violations contendo ownerType
+- `POST /accounts` sem `ownerId` â†’ 400 + violations
+- `POST /accounts` duplicado â†’ 409 + errorCode
+- `POST /transfers` com `idempotencyKey` repetida â†’ 409 + errorCode + meta
+- API key ausente â†’ 401 + errorCode
 
 ### Definition of Done
 - Todas as rotas retornam erros no mesmo formato
 - `traceId` presente sempre
-- Sem mensagens genéricas sem detalhe
-- Testes cobrindo os principais cenários
+- Sem mensagens genÃ©ricas sem detalhe
+- Testes cobrindo os principais cenÃ¡rios
 
 ---
 
 ## Notas
 
-- O domínio do Ledger não deve ser exposto em erros (sem IDs/entidades internas além do necessário).
-- Preferir mensagens úteis, mas não vazar detalhes sensíveis (ex.: stacktrace).
+- O domÃ­nio do Ledger nÃ£o deve ser exposto em erros (sem IDs/entidades internas alÃ©m do necessÃ¡rio).
+- Preferir mensagens Ãºteis, mas nÃ£o vazar detalhes sensÃ­veis (ex.: stacktrace).
+
+
 

--- a/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
+++ b/docs/adr_erros_padronizados_e_validacao_declarativa_na_wallet_api.md
@@ -1,4 +1,4 @@
-﻿# ADR â€” Erros Padronizados e ValidaÃ§Ã£o Declarativa na Wallet API
+﻿# ADR — Erros Padronizados e Validação Declarativa na Wallet API
 
 - **Status:** Accepted
 - **Data:** 2026-01-25
@@ -8,78 +8,78 @@
 
 ## Contexto
 
-Durante testes do MVP da Wallet, ocorreram respostas **400 genÃ©ricas** (ex.: â€œSolicitaÃ§Ã£o InvÃ¡lidaâ€) quando o payload possuÃ­a valores invÃ¡lidos (ex.: `ownerType` diferente de `CUSTOMER`). Isso dificulta o uso por clientes externos, aumenta tempo de integraÃ§Ã£o e gera suporte desnecessÃ¡rio.
+Durante testes do MVP da Wallet, ocorreram respostas **400 genéricas** (ex.: “Solicitação Inválida”) quando o payload possuía valores inválidos (ex.: `ownerType` diferente de `CUSTOMER`). Isso dificulta o uso por clientes externos, aumenta tempo de integração e gera suporte desnecessário.
 
 O comportamento atual usa `try/catch` de `IllegalArgumentException` no resource e retorna `WebApplicationException` sem um contrato de erro consistente.
 
-A especificaÃ§Ã£o do MVP introduziu o requisito **RF-06 â€” Modelo de Erro (Developer-friendly)**, recomendando um formato estruturado baseado em **Problem Details (RFC 7807)** com `errorCode`, `violations[]` e `traceId`.
+A especificação do MVP introduziu o requisito **RF-06 — Modelo de Erro (Developer-friendly)**, recomendando um formato estruturado baseado em **Problem Details (RFC 7807)** com `errorCode`, `violations[]` e `traceId`.
 
 ---
 
-## DecisÃ£o
+## Decisão
 
 Adotar na Wallet API:
 
-1) **ValidaÃ§Ã£o declarativa (Bean Validation)** nos DTOs de request (ex.: `CreateWalletAccountRequest`, `CreateTransferRequest`).
+1) **Validação declarativa (Bean Validation)** nos DTOs de request (ex.: `CreateWalletAccountRequest`, `CreateTransferRequest`).
 
 2) **Erros padronizados** no formato **Problem Details** (RFC 7807 ou equivalente), contendo:
 - `type`, `title`, `status`, `detail`, `instance`
 - `errorCode`
-- `violations[]` (quando aplicÃ¡vel)
+- `violations[]` (quando aplicável)
 - `traceId`
 
-3) **Exception Mappers (JAX-RS)** para transformar exceÃ§Ãµes em respostas consistentes:
-- validaÃ§Ã£o de payload â†’ 400 com `violations`
-- conflitos de negÃ³cio (ex.: conta jÃ¡ existe) â†’ 409
-- nÃ£o encontrado â†’ 404
-- nÃ£o autorizado (API key invÃ¡lida) â†’ 401
+3) **Exception Mappers (JAX-RS)** para transformar exceções em respostas consistentes:
+- validação de payload → 400 com `violations`
+- conflitos de negócio (ex.: conta já existe) → 409
+- não encontrado → 404
+- não autorizado (API key inválida) → 401
 
-4) **CorrelaÃ§Ãµes de requisiÃ§Ã£o**: gerar/propagar `traceId` e incluir em logs + resposta.
+4) **Correlações de requisição**: gerar/propagar `traceId` e incluir em logs + resposta.
 
 ---
 
-## MotivaÃ§Ãµes
+## Motivações
 
-- Melhorar DX (Developer Experience) e reduzir fricÃ§Ã£o de integraÃ§Ã£o
-- Tornar o MVP vendÃ¡vel (API autoexplicativa)
-- Evitar â€œdebug lendo cÃ³digoâ€ em situaÃ§Ãµes comuns
-- Padronizar o tratamento de erros desde o inÃ­cio
+- Melhorar DX (Developer Experience) e reduzir fricção de integração
+- Tornar o MVP vendável (API autoexplicativa)
+- Evitar “debug lendo código” em situações comuns
+- Padronizar o tratamento de erros desde o início
 
 ---
 
 ## Alternativas consideradas
 
 ### A) Manter `try/catch` no resource com mensagens simples
-- **PrÃ³s:** rÃ¡pido
-- **Contras:** inconsistÃªncia, difÃ­cil padronizar, nÃ£o escala
+- **Prós:** rápido
+- **Contras:** inconsistência, difícil padronizar, não escala
 
 ### B) Retornar apenas mensagens de texto
-- **PrÃ³s:** simples
-- **Contras:** nÃ£o suporta erros por campo e automaÃ§Ã£o do cliente
+- **Prós:** simples
+- **Contras:** não suporta erros por campo e automação do cliente
 
 ### C) Expor o ledger para debug
-- **PrÃ³s:** facilita testes internos
-- **Contras:** quebra encapsulamento e seguranÃ§a do produto
+- **Prós:** facilita testes internos
+- **Contras:** quebra encapsulamento e segurança do produto
 
 ---
 
-## ConsequÃªncias
+## Consequências
 
 ### Positivas
 - Contrato claro para clientes externos
-- ReduÃ§Ã£o de suporte e tempo de integraÃ§Ã£o
+- Redução de suporte e tempo de integração
 - Melhor observabilidade com `traceId`
 
 ### Negativas / Custos
 - Implementar DTO validations + exception mappers
-- Manter catÃ¡logo de `errorCode`
+- Manter catálogo de `errorCode`
 
 ---
 
-## EspecificaÃ§Ã£o de ImplementaÃ§Ã£o (para Codex)
+## Especificação de Implementação (para Codex)
 
 ### Objetivo
-Implementar validaÃ§Ã£o declarativa e erros padronizados no **mÃ³dulo Wallet**, atendendo o requisito **RF-06** do documento â€œEspecificaÃ§Ã£o â€” Fase 1: Wallet API sobre Ledger (MVP VendÃ¡vel)â€.
+Implementar validação declarativa e erros padronizados no **módulo Wallet**, atendendo o requisito **RF-06** do documento “Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)”.
 
 ### Escopo
 Aplicar em endpoints:
@@ -89,7 +89,7 @@ Aplicar em endpoints:
 - `POST /transfers`
 
 ### Regras de contrato de erro
-Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Details + extensÃµes):
+Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Details + extensões):
 
 ```json
 {
@@ -106,44 +106,44 @@ Todas as respostas de erro DEVEM retornar JSON no formato abaixo (Problem Detail
 }
 ```
 
-- `violations` Ã© obrigatÃ³rio apenas para erros de validaÃ§Ã£o.
+- `violations` é obrigatório apenas para erros de validação.
 - `traceId` deve sempre existir.
 
 ### Mapeamento de erros
 
-#### 400 â€” Validation error
+#### 400 — Validation error
 - Quando Bean Validation falhar (ex.: `ConstraintViolationException`, `ResteasyReactiveViolationException`)
 - `errorCode = WALLET_VALIDATION_ERROR`
 - Preencher `violations[]`
 
-Casos mÃ­nimos:
-- `ownerType` invÃ¡lido â†’ mensagem deve listar valores permitidos (`CUSTOMER`, `INTERNAL`)
+Casos mínimos:
+- `ownerType` inválido → mensagem deve listar valores permitidos (`CUSTOMER`, `INTERNAL`)
 - `ownerId` vazio
-- `currency` invÃ¡lida
+- `currency` inválida
 
-#### 401 â€” Unauthorized
-- API key ausente/invÃ¡lida
+#### 401 — Unauthorized
+- API key ausente/inválida
 - `errorCode = WALLET_UNAUTHORIZED`
 
-#### 404 â€” Not Found
-- WalletAccount nÃ£o encontrada (no tenant)
+#### 404 — Not Found
+- WalletAccount não encontrada (no tenant)
 - `errorCode = WALLET_ACCOUNT_NOT_FOUND`
 
-#### 409 â€” Conflict
-- Conta jÃ¡ existe (unicidade)
+#### 409 — Conflict
+- Conta já existe (unicidade)
 - `errorCode = WALLET_ACCOUNT_ALREADY_EXISTS`
-- IdempotÃªncia: `idempotencyKey` jÃ¡ usada no mesmo tenant
+- Idempotência: `idempotencyKey` já usada no mesmo tenant
 - `errorCode = WALLET_IDEMPOTENCY_CONFLICT`
 - Retornar `meta.transactionId` e `meta.idempotencyKey`
 
-#### 500 â€” Unexpected
-- Qualquer exceÃ§Ã£o nÃ£o mapeada
+#### 500 — Unexpected
+- Qualquer exceção não mapeada
 - `errorCode = WALLET_INTERNAL_ERROR`
 
 ### DTOs: adicionar Bean Validation
 
 #### CreateWalletAccountRequest
-- `ownerType`: `@NotBlank` + validaÃ§Ã£o de enum (CUSTOMER/INTERNAL)
+- `ownerType`: `@NotBlank` + validação de enum (CUSTOMER/INTERNAL)
 - `ownerId`: `@NotBlank`
 - `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
 - `label`: opcional
@@ -156,8 +156,8 @@ Casos mÃ­nimos:
 - `currency`: `@NotBlank` + `@Pattern(regexp = "^[A-Z]{3}$")`
 
 ### Enum parsing (evitar valueOf direto)
-- Implementar um `@ValidEnum` custom annotation OU um `ParamConverter`/`JsonbAdapter` para mapear string â†’ enum com erro amigÃ¡vel.
-- Se `ownerType` for invÃ¡lido, retornar 400 com `violations` e valores permitidos.
+- Implementar um `@ValidEnum` custom annotation OU um `ParamConverter`/`JsonbAdapter` para mapear string → enum com erro amigável.
+- Se `ownerType` for inválido, retornar 400 com `violations` e valores permitidos.
 
 ### Exception Mappers
 Implementar `@Provider` mappers:
@@ -165,42 +165,43 @@ Implementar `@Provider` mappers:
 1) `ValidationExceptionMapper`
 - Converte violations em lista ordenada por campo
 
-2) `WebApplicationExceptionMapper` (ou especÃ­fico)
-- Padroniza respostas para 401/404/409 lanÃ§adas pela aplicaÃ§Ã£o
+2) `WebApplicationExceptionMapper` (ou específico)
+- Padroniza respostas para 401/404/409 lançadas pela aplicação
 
 3) `ThrowableMapper`
 - Fallback 500 com `traceId`
 
 ### TraceId / Correlation
 - Se request tiver header `X-Request-Id`, reutilizar
-- SenÃ£o gerar UUID
+- Senão gerar UUID
 - Incluir `traceId` na resposta e log
 - Ideal: `ContainerRequestFilter` + `ContainerResponseFilter`
 
-### RefatoraÃ§Ã£o do resource
+### Refatoração do resource
 - Remover `try/catch IllegalArgumentException` do resource
-- Deixar o resource â€œfinoâ€, delegando validaÃ§Ã£o ao Bean Validation e regras ao use case
+- Deixar o resource “fino”, delegando validação ao Bean Validation e regras ao use case
 
-### Testes de integraÃ§Ã£o (mÃ­nimos)
+### Testes de integração (mínimos)
 Criar testes que validem payload e formato de erro:
-- `POST /accounts` com `ownerType=FUNDER` â†’ 400 + violations contendo ownerType
-- `POST /accounts` sem `ownerId` â†’ 400 + violations
-- `POST /accounts` duplicado â†’ 409 + errorCode
-- `POST /transfers` com `idempotencyKey` repetida â†’ 409 + errorCode + meta
-- API key ausente â†’ 401 + errorCode
+- `POST /accounts` com `ownerType=FUNDER` → 400 + violations contendo ownerType
+- `POST /accounts` sem `ownerId` → 400 + violations
+- `POST /accounts` duplicado → 409 + errorCode
+- `POST /transfers` com `idempotencyKey` repetida → 409 + errorCode + meta
+- API key ausente → 401 + errorCode
 
 ### Definition of Done
 - Todas as rotas retornam erros no mesmo formato
 - `traceId` presente sempre
-- Sem mensagens genÃ©ricas sem detalhe
-- Testes cobrindo os principais cenÃ¡rios
+- Sem mensagens genéricas sem detalhe
+- Testes cobrindo os principais cenários
 
 ---
 
 ## Notas
 
-- O domÃ­nio do Ledger nÃ£o deve ser exposto em erros (sem IDs/entidades internas alÃ©m do necessÃ¡rio).
-- Preferir mensagens Ãºteis, mas nÃ£o vazar detalhes sensÃ­veis (ex.: stacktrace).
+- O domínio do Ledger não deve ser exposto em erros (sem IDs/entidades internas além do necessário).
+- Preferir mensagens úteis, mas não vazar detalhes sensíveis (ex.: stacktrace).
+
 
 
 

--- a/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
+++ b/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
@@ -1,8 +1,8 @@
-﻿# EspecificaÃ§Ã£o â€” Fase 1: Wallet API sobre Ledger (MVP VendÃ¡vel)
+﻿# Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)
 
-> Objetivo: transformar o Ledger Core jÃ¡ existente em um **produto utilizÃ¡vel via API**, atravÃ©s de um mÃ³dulo de **Wallet**, permitindo que plataformas criem contas para seus usuÃ¡rios, movimentem saldo entre eles e consultem saldo/extrato de forma segura e multi-tenant.
+> Objetivo: transformar o Ledger Core já existente em um **produto utilizável via API**, através de um módulo de **Wallet**, permitindo que plataformas criem contas para seus usuários, movimentem saldo entre eles e consultem saldo/extrato de forma segura e multi-tenant.
 
-O Ledger continua sendo o **motor contÃ¡bil interno**. A Wallet API Ã© a **camada de produto** exposta a clientes externos.
+O Ledger continua sendo o **motor contábil interno**. A Wallet API é a **camada de produto** exposta a clientes externos.
 
 ---
 
@@ -10,14 +10,14 @@ O Ledger continua sendo o **motor contÃ¡bil interno**. A Wallet API Ã© a **c
 
 Este MVP permite que uma plataforma terceira tenha:
 
-- Contas virtuais para seus usuÃ¡rios finais
-- TransferÃªncias internas entre usuÃ¡rios
-- Saldo confiÃ¡vel e auditÃ¡vel
-- Extrato de movimentaÃ§Ãµes
+- Contas virtuais para seus usuários finais
+- Transferências internas entre usuários
+- Saldo confiável e auditável
+- Extrato de movimentações
 
-Sem precisar construir um motor contÃ¡bil prÃ³prio.
+Sem precisar construir um motor contábil próprio.
 
-Produto posicionÃ¡vel como:
+Produto posicionável como:
 
 > **Wallet / Ledger API para plataformas digitais**
 
@@ -27,38 +27,38 @@ Produto posicionÃ¡vel como:
 
 ### Em escopo
 
-- MÃ³dulo **Wallet** como camada sobre o Ledger
-- API para criaÃ§Ã£o de contas de usuÃ¡rios (WalletAccounts)
+- Módulo **Wallet** como camada sobre o Ledger
+- API para criação de contas de usuários (WalletAccounts)
 - API de consulta de saldo (derivado do Ledger)
 - API de extrato (derivado do Ledger)
-- API de transferÃªncia entre contas
-- IdempotÃªncia em transferÃªncias
+- API de transferência entre contas
+- Idempotência em transferências
 - Multi-tenant via API Key
 
 ### Fora de escopo
 
-- CartÃ£o de crÃ©dito
+- Cartão de crédito
 - Juros e taxas
-- IntegraÃ§Ã£o bancÃ¡ria real
-- Split entre mÃºltiplas partes
+- Integração bancária real
+- Split entre múltiplas partes
 - Webhooks
 
 ---
 
-## 3. Arquitetura LÃ³gica
+## 3. Arquitetura Lógica
 
 ```
 Cliente da API
-       â”‚
-       â–¼
+       │
+       ▼
    Wallet API  (produto)
-       â”‚
-       â–¼
-   Ledger Core (motor contÃ¡bil)
+       │
+       ▼
+   Ledger Core (motor contábil)
 ```
 
 - A Wallet **nunca altera saldo diretamente**.
-- Toda movimentaÃ§Ã£o financeira Ã© feita via **LedgerTransaction**.
+- Toda movimentação financeira é feita via **LedgerTransaction**.
 
 ---
 
@@ -66,55 +66,55 @@ Cliente da API
 
 ### 4.1 LedgerAccount
 
-Conta contÃ¡bil real do nÃºcleo do ledger que participa de lanÃ§amentos (entries) e cÃ¡lculo de saldo.
+Conta contábil real do núcleo do ledger que participa de lançamentos (entries) e cálculo de saldo.
 
-CaracterÃ­sticas:
+Características:
 
 - Pertence a um `tenantId`
 - Possui `currency`, `type`, `allowNegative`
-- NÃ£o conhece usuÃ¡rio, produto ou wallet
+- Não conhece usuário, produto ou wallet
 
 ---
 
-### 4.2 WalletAccount (novo â€” camada de produto)
+### 4.2 WalletAccount (novo — camada de produto)
 
 Representa a conta exposta ao cliente da API.
 
-Ela Ã© um **espelho funcional** de uma `LedgerAccount`.
+Ela é um **espelho funcional** de uma `LedgerAccount`.
 
 Campos principais:
 
 - `accountId` (UUID da Wallet)
 - `tenantId`
 - `ownerType` (ex: CUSTOMER)
-- `ownerId` (ID do usuÃ¡rio no sistema do cliente)
+- `ownerId` (ID do usuário no sistema do cliente)
 - `currency`
 - `status`
 - `label` (opcional)
-- `ledgerAccountId` (FK lÃ³gica para LedgerAccount)
+- `ledgerAccountId` (FK lógica para LedgerAccount)
 
-**Regra:** WalletAccount nÃ£o armazena saldo. Saldo e extrato sÃ£o sempre consultados no Ledger.
+**Regra:** WalletAccount não armazena saldo. Saldo e extrato são sempre consultados no Ledger.
 
-RestriÃ§Ã£o inicial:
+Restrição inicial:
 
 > 1 WalletAccount principal por (tenantId, ownerType, ownerId, currency)
 
 ---
 
-### 4.3 TransferÃªncia
+### 4.3 Transferência
 
-MovimentaÃ§Ã£o de saldo entre duas WalletAccounts do mesmo tenant.
+Movimentação de saldo entre duas WalletAccounts do mesmo tenant.
 
-A Wallet traduz a operaÃ§Ã£o para o Ledger como:
+A Wallet traduz a operação para o Ledger como:
 
 - DEBIT na LedgerAccount de origem
 - CREDIT na LedgerAccount de destino
 
 ---
 
-### 4.4 ResoluÃ§Ã£o de Tenant
+### 4.4 Resolução de Tenant
 
-Cada requisiÃ§Ã£o deve conter:
+Cada requisição deve conter:
 
 ```
 X-API-Key: <apiKey>
@@ -122,15 +122,15 @@ X-API-Key: <apiKey>
 
 Fluxo:
 
-1. API Key â†’ resolve `tenantId`
-2. `tenantId` Ã© propagado para todos os use cases do Ledger
-3. Ã‰ proibida qualquer operaÃ§Ã£o entre tenants diferentes
+1. API Key → resolve `tenantId`
+2. `tenantId` é propagado para todos os use cases do Ledger
+3. É proibida qualquer operação entre tenants diferentes
 
 ---
 
 ## 5. Requisitos Funcionais
 
-### RF-01 â€” Criar Conta (WalletAccount)
+### RF-01 — Criar Conta (WalletAccount)
 
 **POST /accounts**
 
@@ -170,14 +170,14 @@ Response:
 
 ---
 
-### RF-02 â€” Consultar Saldo
+### RF-02 — Consultar Saldo
 
 **GET /accounts/{accountId}/balance**
 
 Processo:
 
 - Resolver `tenantId`
-- Buscar WalletAccount â†’ obter `ledgerAccountId`
+- Buscar WalletAccount → obter `ledgerAccountId`
 - Chamar Ledger: `GetBalance(tenantId, ledgerAccountId)`
 
 Response:
@@ -192,14 +192,14 @@ Response:
 
 ---
 
-### RF-03 â€” Extrato da Conta
+### RF-03 — Extrato da Conta
 
 **GET /accounts/{accountId}/statement**
 
 Processo:
 
 - Resolver `tenantId`
-- Buscar WalletAccount â†’ `ledgerAccountId`
+- Buscar WalletAccount → `ledgerAccountId`
 - Consultar Ledger por entries da conta
 
 Response:
@@ -222,7 +222,7 @@ Response:
 
 ---
 
-### RF-04 â€” TransferÃªncia entre Contas
+### RF-04 — Transferência entre Contas
 
 **POST /transfers**
 
@@ -284,26 +284,26 @@ Exemplo de resposta 409:
 
 ---
 
-## 6. SeguranÃ§a
+## 6. Segurança
 
-- AutenticaÃ§Ã£o via API Key
-- Todas as operaÃ§Ãµes isoladas por `tenantId`
+- Autenticação via API Key
+- Todas as operações isoladas por `tenantId`
 - Proibido acesso a contas de outro tenant
 
 ---
 
-## 7. Requisitos NÃ£o Funcionais
+## 7. Requisitos Não Funcionais
 
-- OperaÃ§Ãµes financeiras atÃ´micas
-- Ledger permanece imutÃ¡vel
+- Operações financeiras atômicas
+- Ledger permanece imutável
 - Logs com tenantId + idempotencyKey
 - Rate limit por API Key
 
 ---
 
-## 8. Estrutura TÃ©cnica Esperada
+## 8. Estrutura Técnica Esperada
 
-Novos mÃ³dulos:
+Novos módulos:
 
 ```
 /wallet/api
@@ -319,22 +319,23 @@ Reutilizando:
 
 ---
 
-## 9. EntregÃ¡veis da Fase 1
+## 9. Entregáveis da Fase 1
 
 - Entidade WalletAccount
-- IntegraÃ§Ã£o Wallet â†’ LedgerAccount
+- Integração Wallet → LedgerAccount
 - Endpoints REST de accounts e transfers
 - Use case TransferBetweenAccounts
-- Testes de integraÃ§Ã£o multi-tenant
+- Testes de integração multi-tenant
 
 ---
 
 ## 10. Resultado Esperado
 
-Ao final da Fase 1 serÃ¡ possÃ­vel demonstrar:
+Ao final da Fase 1 será possível demonstrar:
 
-> â€œCriar contas de usuÃ¡rios, movimentar saldo entre eles e consultar extratos via API multi-tenant.â€
+> “Criar contas de usuários, movimentar saldo entre eles e consultar extratos via API multi-tenant.”
 
-Base pronta para monetizaÃ§Ã£o como **Wallet / Ledger API**.
+Base pronta para monetização como **Wallet / Ledger API**.
+
 
 

--- a/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
+++ b/docs/especificacao_fase_1_ledger_como_api_de_contas_mvp_vendavel.md
@@ -1,8 +1,8 @@
-# Especificação — Fase 1: Wallet API sobre Ledger (MVP Vendável)
+﻿# EspecificaÃ§Ã£o â€” Fase 1: Wallet API sobre Ledger (MVP VendÃ¡vel)
 
-> Objetivo: transformar o Ledger Core já existente em um **produto utilizável via API**, através de um módulo de **Wallet**, permitindo que plataformas criem contas para seus usuários, movimentem saldo entre eles e consultem saldo/extrato de forma segura e multi-tenant.
+> Objetivo: transformar o Ledger Core jÃ¡ existente em um **produto utilizÃ¡vel via API**, atravÃ©s de um mÃ³dulo de **Wallet**, permitindo que plataformas criem contas para seus usuÃ¡rios, movimentem saldo entre eles e consultem saldo/extrato de forma segura e multi-tenant.
 
-O Ledger continua sendo o **motor contábil interno**. A Wallet API é a **camada de produto** exposta a clientes externos.
+O Ledger continua sendo o **motor contÃ¡bil interno**. A Wallet API Ã© a **camada de produto** exposta a clientes externos.
 
 ---
 
@@ -10,14 +10,14 @@ O Ledger continua sendo o **motor contábil interno**. A Wallet API é a **camad
 
 Este MVP permite que uma plataforma terceira tenha:
 
-- Contas virtuais para seus usuários finais
-- Transferências internas entre usuários
-- Saldo confiável e auditável
-- Extrato de movimentações
+- Contas virtuais para seus usuÃ¡rios finais
+- TransferÃªncias internas entre usuÃ¡rios
+- Saldo confiÃ¡vel e auditÃ¡vel
+- Extrato de movimentaÃ§Ãµes
 
-Sem precisar construir um motor contábil próprio.
+Sem precisar construir um motor contÃ¡bil prÃ³prio.
 
-Produto posicionável como:
+Produto posicionÃ¡vel como:
 
 > **Wallet / Ledger API para plataformas digitais**
 
@@ -27,38 +27,38 @@ Produto posicionável como:
 
 ### Em escopo
 
-- Módulo **Wallet** como camada sobre o Ledger
-- API para criação de contas de usuários (WalletAccounts)
+- MÃ³dulo **Wallet** como camada sobre o Ledger
+- API para criaÃ§Ã£o de contas de usuÃ¡rios (WalletAccounts)
 - API de consulta de saldo (derivado do Ledger)
 - API de extrato (derivado do Ledger)
-- API de transferência entre contas
-- Idempotência em transferências
+- API de transferÃªncia entre contas
+- IdempotÃªncia em transferÃªncias
 - Multi-tenant via API Key
 
 ### Fora de escopo
 
-- Cartão de crédito
+- CartÃ£o de crÃ©dito
 - Juros e taxas
-- Integração bancária real
-- Split entre múltiplas partes
+- IntegraÃ§Ã£o bancÃ¡ria real
+- Split entre mÃºltiplas partes
 - Webhooks
 
 ---
 
-## 3. Arquitetura Lógica
+## 3. Arquitetura LÃ³gica
 
 ```
 Cliente da API
-       │
-       ▼
+       â”‚
+       â–¼
    Wallet API  (produto)
-       │
-       ▼
-   Ledger Core (motor contábil)
+       â”‚
+       â–¼
+   Ledger Core (motor contÃ¡bil)
 ```
 
 - A Wallet **nunca altera saldo diretamente**.
-- Toda movimentação financeira é feita via **LedgerTransaction**.
+- Toda movimentaÃ§Ã£o financeira Ã© feita via **LedgerTransaction**.
 
 ---
 
@@ -66,55 +66,55 @@ Cliente da API
 
 ### 4.1 LedgerAccount
 
-Conta contábil real do núcleo do ledger que participa de lançamentos (entries) e cálculo de saldo.
+Conta contÃ¡bil real do nÃºcleo do ledger que participa de lanÃ§amentos (entries) e cÃ¡lculo de saldo.
 
-Características:
+CaracterÃ­sticas:
 
 - Pertence a um `tenantId`
 - Possui `currency`, `type`, `allowNegative`
-- Não conhece usuário, produto ou wallet
+- NÃ£o conhece usuÃ¡rio, produto ou wallet
 
 ---
 
-### 4.2 WalletAccount (novo — camada de produto)
+### 4.2 WalletAccount (novo â€” camada de produto)
 
 Representa a conta exposta ao cliente da API.
 
-Ela é um **espelho funcional** de uma `LedgerAccount`.
+Ela Ã© um **espelho funcional** de uma `LedgerAccount`.
 
 Campos principais:
 
 - `accountId` (UUID da Wallet)
 - `tenantId`
 - `ownerType` (ex: CUSTOMER)
-- `ownerId` (ID do usuário no sistema do cliente)
+- `ownerId` (ID do usuÃ¡rio no sistema do cliente)
 - `currency`
 - `status`
 - `label` (opcional)
-- `ledgerAccountId` (FK lógica para LedgerAccount)
+- `ledgerAccountId` (FK lÃ³gica para LedgerAccount)
 
-**Regra:** WalletAccount não armazena saldo. Saldo e extrato são sempre consultados no Ledger.
+**Regra:** WalletAccount nÃ£o armazena saldo. Saldo e extrato sÃ£o sempre consultados no Ledger.
 
-Restrição inicial:
+RestriÃ§Ã£o inicial:
 
 > 1 WalletAccount principal por (tenantId, ownerType, ownerId, currency)
 
 ---
 
-### 4.3 Transferência
+### 4.3 TransferÃªncia
 
-Movimentação de saldo entre duas WalletAccounts do mesmo tenant.
+MovimentaÃ§Ã£o de saldo entre duas WalletAccounts do mesmo tenant.
 
-A Wallet traduz a operação para o Ledger como:
+A Wallet traduz a operaÃ§Ã£o para o Ledger como:
 
 - DEBIT na LedgerAccount de origem
 - CREDIT na LedgerAccount de destino
 
 ---
 
-### 4.4 Resolução de Tenant
+### 4.4 ResoluÃ§Ã£o de Tenant
 
-Cada requisição deve conter:
+Cada requisiÃ§Ã£o deve conter:
 
 ```
 X-API-Key: <apiKey>
@@ -122,15 +122,15 @@ X-API-Key: <apiKey>
 
 Fluxo:
 
-1. API Key → resolve `tenantId`
-2. `tenantId` é propagado para todos os use cases do Ledger
-3. É proibida qualquer operação entre tenants diferentes
+1. API Key â†’ resolve `tenantId`
+2. `tenantId` Ã© propagado para todos os use cases do Ledger
+3. Ã‰ proibida qualquer operaÃ§Ã£o entre tenants diferentes
 
 ---
 
 ## 5. Requisitos Funcionais
 
-### RF-01 — Criar Conta (WalletAccount)
+### RF-01 â€” Criar Conta (WalletAccount)
 
 **POST /accounts**
 
@@ -170,14 +170,14 @@ Response:
 
 ---
 
-### RF-02 — Consultar Saldo
+### RF-02 â€” Consultar Saldo
 
 **GET /accounts/{accountId}/balance**
 
 Processo:
 
 - Resolver `tenantId`
-- Buscar WalletAccount → obter `ledgerAccountId`
+- Buscar WalletAccount â†’ obter `ledgerAccountId`
 - Chamar Ledger: `GetBalance(tenantId, ledgerAccountId)`
 
 Response:
@@ -192,14 +192,14 @@ Response:
 
 ---
 
-### RF-03 — Extrato da Conta
+### RF-03 â€” Extrato da Conta
 
 **GET /accounts/{accountId}/statement**
 
 Processo:
 
 - Resolver `tenantId`
-- Buscar WalletAccount → `ledgerAccountId`
+- Buscar WalletAccount â†’ `ledgerAccountId`
 - Consultar Ledger por entries da conta
 
 Response:
@@ -222,7 +222,7 @@ Response:
 
 ---
 
-### RF-04 — Transferência entre Contas
+### RF-04 â€” TransferÃªncia entre Contas
 
 **POST /transfers**
 
@@ -259,28 +259,51 @@ Resposta:
 }
 ```
 
+Em caso de `idempotencyKey` ja usado no mesmo tenant, retornar **409 Conflict** com:
+- `errorCode`: `WALLET_IDEMPOTENCY_CONFLICT`
+- `meta.transactionId`: ID da transacao existente
+- `meta.idempotencyKey`: chave enviada
+
+Exemplo de resposta 409:
+
+```json
+{
+  "type": "https://errors.yourdomain.com/conflict",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "idempotencyKey already used for this tenant",
+  "instance": "/transfers",
+  "errorCode": "WALLET_IDEMPOTENCY_CONFLICT",
+  "meta": {
+    "transactionId": "existing-transaction-uuid",
+    "idempotencyKey": "txn-123"
+  },
+  "traceId": "request-trace-id"
+}
+```
+
 ---
 
-## 6. Segurança
+## 6. SeguranÃ§a
 
-- Autenticação via API Key
-- Todas as operações isoladas por `tenantId`
+- AutenticaÃ§Ã£o via API Key
+- Todas as operaÃ§Ãµes isoladas por `tenantId`
 - Proibido acesso a contas de outro tenant
 
 ---
 
-## 7. Requisitos Não Funcionais
+## 7. Requisitos NÃ£o Funcionais
 
-- Operações financeiras atômicas
-- Ledger permanece imutável
+- OperaÃ§Ãµes financeiras atÃ´micas
+- Ledger permanece imutÃ¡vel
 - Logs com tenantId + idempotencyKey
 - Rate limit por API Key
 
 ---
 
-## 8. Estrutura Técnica Esperada
+## 8. Estrutura TÃ©cnica Esperada
 
-Novos módulos:
+Novos mÃ³dulos:
 
 ```
 /wallet/api
@@ -296,21 +319,22 @@ Reutilizando:
 
 ---
 
-## 9. Entregáveis da Fase 1
+## 9. EntregÃ¡veis da Fase 1
 
 - Entidade WalletAccount
-- Integração Wallet → LedgerAccount
+- IntegraÃ§Ã£o Wallet â†’ LedgerAccount
 - Endpoints REST de accounts e transfers
 - Use case TransferBetweenAccounts
-- Testes de integração multi-tenant
+- Testes de integraÃ§Ã£o multi-tenant
 
 ---
 
 ## 10. Resultado Esperado
 
-Ao final da Fase 1 será possível demonstrar:
+Ao final da Fase 1 serÃ¡ possÃ­vel demonstrar:
 
-> “Criar contas de usuários, movimentar saldo entre eles e consultar extratos via API multi-tenant.”
+> â€œCriar contas de usuÃ¡rios, movimentar saldo entre eles e consultar extratos via API multi-tenant.â€
 
-Base pronta para monetização como **Wallet / Ledger API**.
+Base pronta para monetizaÃ§Ã£o como **Wallet / Ledger API**.
+
 

--- a/src/main/java/com/sistema/common/api/error/ErrorResponse.java
+++ b/src/main/java/com/sistema/common/api/error/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.sistema.common.api.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.Map;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -15,6 +16,8 @@ public class ErrorResponse {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ErrorViolation> violations;
     private String traceId;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, Object> meta;
 
     public String getType() {
         return type;
@@ -78,6 +81,14 @@ public class ErrorResponse {
 
     public void setTraceId(String traceId) {
         this.traceId = traceId;
+    }
+
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Map<String, Object> meta) {
+        this.meta = meta;
     }
 }
 

--- a/src/main/java/com/sistema/common/api/error/ErrorResponseFactory.java
+++ b/src/main/java/com/sistema/common/api/error/ErrorResponseFactory.java
@@ -4,6 +4,7 @@ import com.sistema.common.api.trace.TraceIdProvider;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.List;
+import java.util.Map;
 
 public final class ErrorResponseFactory {
     private ErrorResponseFactory() {
@@ -17,6 +18,18 @@ public final class ErrorResponseFactory {
                                       String errorCode,
                                       List<ErrorViolation> violations,
                                       TraceIdProvider traceIdProvider) {
+        return build(type, title, status, detail, instance, errorCode, violations, null, traceIdProvider);
+    }
+
+    public static ErrorResponse build(String type,
+                                      String title,
+                                      int status,
+                                      String detail,
+                                      String instance,
+                                      String errorCode,
+                                      List<ErrorViolation> violations,
+                                      Map<String, Object> meta,
+                                      TraceIdProvider traceIdProvider) {
         ErrorResponse response = new ErrorResponse();
         response.setType(type);
         response.setTitle(title);
@@ -25,6 +38,7 @@ public final class ErrorResponseFactory {
         response.setInstance(instance);
         response.setErrorCode(errorCode);
         response.setViolations(violations);
+        response.setMeta(meta);
         response.setTraceId(traceIdProvider.getTraceId());
         return response;
     }

--- a/src/main/java/com/sistema/ledger/application/model/PostLedgerTransactionResult.java
+++ b/src/main/java/com/sistema/ledger/application/model/PostLedgerTransactionResult.java
@@ -1,0 +1,21 @@
+package com.sistema.ledger.application.model;
+
+import com.sistema.ledger.domain.model.LedgerTransaction;
+
+public class PostLedgerTransactionResult {
+    private final LedgerTransaction transaction;
+    private final boolean idempotentReplay;
+
+    public PostLedgerTransactionResult(LedgerTransaction transaction, boolean idempotentReplay) {
+        this.transaction = transaction;
+        this.idempotentReplay = idempotentReplay;
+    }
+
+    public LedgerTransaction getTransaction() {
+        return transaction;
+    }
+
+    public boolean isIdempotentReplay() {
+        return idempotentReplay;
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletErrorCodes.java
@@ -7,6 +7,7 @@ public final class WalletErrorCodes {
     public static final String WALLET_ACCOUNT_ALREADY_EXISTS = "WALLET_ACCOUNT_ALREADY_EXISTS";
     public static final String WALLET_OWNER_NOT_FOUND = "WALLET_OWNER_NOT_FOUND";
     public static final String WALLET_INSUFFICIENT_BALANCE = "WALLET_INSUFFICIENT_BALANCE";
+    public static final String WALLET_IDEMPOTENCY_CONFLICT = "WALLET_IDEMPOTENCY_CONFLICT";
     public static final String WALLET_INTERNAL_ERROR = "WALLET_INTERNAL_ERROR";
 
     private WalletErrorCodes() {

--- a/src/main/java/com/sistema/wallet/api/error/WalletExceptionMapper.java
+++ b/src/main/java/com/sistema/wallet/api/error/WalletExceptionMapper.java
@@ -33,6 +33,7 @@ public class WalletExceptionMapper implements ExceptionMapper<WalletException> {
                 ErrorResponseFactory.resolveInstance(uriInfo),
                 exception.getErrorCode(),
                 null,
+                exception.getMeta(),
                 traceIdProvider
         );
         return Response.status(status).entity(response).build();

--- a/src/main/java/com/sistema/wallet/application/exception/WalletException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletException.java
@@ -3,11 +3,17 @@ package com.sistema.wallet.application.exception;
 public abstract class WalletException extends RuntimeException {
     private final int status;
     private final String errorCode;
+    private final java.util.Map<String, Object> meta;
 
     protected WalletException(String message, int status, String errorCode) {
+        this(message, status, errorCode, null);
+    }
+
+    protected WalletException(String message, int status, String errorCode, java.util.Map<String, Object> meta) {
         super(message);
         this.status = status;
         this.errorCode = errorCode;
+        this.meta = meta;
     }
 
     public int getStatus() {
@@ -16,5 +22,9 @@ public abstract class WalletException extends RuntimeException {
 
     public String getErrorCode() {
         return errorCode;
+    }
+
+    public java.util.Map<String, Object> getMeta() {
+        return meta;
     }
 }

--- a/src/main/java/com/sistema/wallet/application/exception/WalletIdempotencyConflictException.java
+++ b/src/main/java/com/sistema/wallet/application/exception/WalletIdempotencyConflictException.java
@@ -1,0 +1,17 @@
+package com.sistema.wallet.application.exception;
+
+import com.sistema.wallet.api.error.WalletErrorCodes;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class WalletIdempotencyConflictException extends WalletException {
+    public WalletIdempotencyConflictException(String idempotencyKey, UUID transactionId) {
+        super("idempotencyKey already used for this tenant", 409,
+                WalletErrorCodes.WALLET_IDEMPOTENCY_CONFLICT,
+                Map.of(
+                        "idempotencyKey", idempotencyKey,
+                        "transactionId", transactionId.toString()
+                ));
+    }
+}


### PR DESCRIPTION
Summary: 

- Wallet transfers return 409 Conflict on idempotency replay with metadata, and docs now include the full 409 example payload.

Changes:

- Added replay-aware result in ledger use case and surfaced it in wallet transfer flow to throw WALLET_IDEMPOTENCY_CONFLICT with meta.transactionId and meta.idempotencyKey.

- Extended error responses to support meta and wired it into the wallet exception mapper.

- Added tests for idempotency replay and updated wallet error docs/specs with the 409 example JSON.