### PR TITLE
feat: prevent self-transfers in wallet and ledger

### DIFF
--- a/src/main/java/com/sistema/ledger/application/rules/DistinctAccountsRule.java
+++ b/src/main/java/com/sistema/ledger/application/rules/DistinctAccountsRule.java
@@ -1,0 +1,17 @@
+package com.sistema.ledger.application.rules;
+
+import com.sistema.ledger.domain.validation.LedgerPostingPolicy;
+
+import java.util.Optional;
+
+public class DistinctAccountsRule implements LedgerPostingRule {
+    @Override
+    public Optional<LedgerRuleViolation> validate(LedgerPostingRuleContext context) {
+        try {
+            new LedgerPostingPolicy().validateDistinctAccounts(context.getEntries());
+            return Optional.empty();
+        } catch (IllegalArgumentException ex) {
+            return Optional.of(new LedgerRuleViolation(ex.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/sistema/ledger/application/rules/PostingRulesPipeline.java
+++ b/src/main/java/com/sistema/ledger/application/rules/PostingRulesPipeline.java
@@ -12,6 +12,7 @@ public class PostingRulesPipeline {
     public PostingRulesPipeline(EntryRepository entryRepository) {
         this.rules = List.of(
                 new EntriesCountRule(),
+                new DistinctAccountsRule(),
                 new AccountStatusActiveRule(),
                 new CrossTenantRule(),
                 new CurrencyMatchRule(),

--- a/src/main/java/com/sistema/ledger/domain/validation/LedgerPostingPolicy.java
+++ b/src/main/java/com/sistema/ledger/domain/validation/LedgerPostingPolicy.java
@@ -6,8 +6,10 @@ import com.sistema.ledger.domain.model.EntryDirection;
 import com.sistema.ledger.domain.model.LedgerAccount;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class LedgerPostingPolicy {
@@ -65,6 +67,19 @@ public class LedgerPostingPolicy {
             long debits = debitByCurrency.getOrDefault(credit.getKey(), 0L);
             if (!credit.getValue().equals(debits)) {
                 throw new IllegalArgumentException("double-entry validation failed for currency " + credit.getKey());
+            }
+        }
+    }
+
+    public void validateDistinctAccounts(List<Entry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+        Set<UUID> accounts = new HashSet<>();
+        for (Entry entry : entries) {
+            UUID accountId = entry.getLedgerAccountId();
+            if (accountId != null && !accounts.add(accountId)) {
+                throw new IllegalArgumentException("entries must target distinct accounts");
             }
         }
     }

--- a/src/main/java/com/sistema/wallet/application/rules/DifferentAccountsRule.java
+++ b/src/main/java/com/sistema/wallet/application/rules/DifferentAccountsRule.java
@@ -1,0 +1,20 @@
+package com.sistema.wallet.application.rules;
+
+import com.sistema.wallet.domain.validation.WalletTransferPolicy;
+
+import java.util.Optional;
+
+public class DifferentAccountsRule implements WalletTransferRule {
+    @Override
+    public Optional<WalletRuleViolation> validate(WalletTransferRuleContext context) {
+        try {
+            new WalletTransferPolicy().validateDifferentAccounts(
+                    context.getFromAccount().getId(),
+                    context.getToAccount().getId()
+            );
+            return Optional.empty();
+        } catch (IllegalArgumentException ex) {
+            return Optional.of(new WalletRuleViolation(ex));
+        }
+    }
+}

--- a/src/main/java/com/sistema/wallet/application/rules/WalletTransferRulesPipeline.java
+++ b/src/main/java/com/sistema/wallet/application/rules/WalletTransferRulesPipeline.java
@@ -13,6 +13,7 @@ public class WalletTransferRulesPipeline {
         this.rules = List.of(
                 new AmountPositiveRule(),
                 new IdempotencyKeyPresentRule(),
+                new DifferentAccountsRule(),
                 new WalletCurrencyMatchRule(),
                 new SufficientBalanceRule(getAccountBalanceUseCase)
         );

--- a/src/main/java/com/sistema/wallet/domain/validation/WalletTransferPolicy.java
+++ b/src/main/java/com/sistema/wallet/domain/validation/WalletTransferPolicy.java
@@ -2,6 +2,8 @@ package com.sistema.wallet.domain.validation;
 
 import com.sistema.wallet.domain.model.WalletOwnerType;
 
+import java.util.UUID;
+
 public class WalletTransferPolicy {
     public void validateAmountPositive(long amountMinor) {
         if (amountMinor <= 0) {
@@ -27,6 +29,12 @@ public class WalletTransferPolicy {
         }
         if (balanceMinor < amountMinor) {
             throw new IllegalArgumentException("insufficient balance");
+        }
+    }
+
+    public void validateDifferentAccounts(UUID fromAccountId, UUID toAccountId) {
+        if (fromAccountId != null && fromAccountId.equals(toAccountId)) {
+            throw new IllegalArgumentException("fromAccountId must be different from toAccountId");
         }
     }
 }

--- a/src/test/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCaseTest.java
+++ b/src/test/java/com/sistema/wallet/application/TransferBetweenWalletAccountsUseCaseTest.java
@@ -215,6 +215,35 @@ class TransferBetweenWalletAccountsUseCaseTest {
     }
 
     @Test
+    void shouldRejectSameWalletAccountTransfer() {
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);
+        PostLedgerTransactionUseCase postLedgerTransactionUseCase = Mockito.mock(PostLedgerTransactionUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID walletId = UUID.randomUUID();
+        UUID ledgerId = UUID.randomUUID();
+
+        when(walletAccountRepository.findById(tenantId, walletId))
+                .thenReturn(Optional.of(walletAccount(walletId, tenantId, ledgerId, "BRL")));
+
+        TransferBetweenWalletAccountsUseCase useCase =
+                new TransferBetweenWalletAccountsUseCase(walletAccountRepository, getAccountBalanceUseCase, postLedgerTransactionUseCase);
+
+        TransferBetweenWalletAccountsCommand command = new TransferBetweenWalletAccountsCommand(
+                "idemp-same",
+                walletId,
+                walletId,
+                5000,
+                "BRL",
+                "transfer"
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(tenantId, command));
+        verify(postLedgerTransactionUseCase, never()).execute(any());
+    }
+
+    @Test
     void shouldRejectInvalidInput() {
         WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
         GetAccountBalanceUseCase getAccountBalanceUseCase = Mockito.mock(GetAccountBalanceUseCase.class);


### PR DESCRIPTION
Summary: Prevent self-transfers by enforcing distinct source/target accounts in both Wallet and Ledger pipelines.
Changes:

- Added a Wallet transfer rule to block same-account transfers and updated the policy validation.

- Added a Ledger posting rule to require distinct accounts per transaction and updated the policy validation.

- Updated unit tests for Ledger posting and Wallet transfers to cover the new rule.