### PR TITLE
feat(payments): add pix payments module

### DIFF
--- a/docs/especificacao_payments_module_pix_sobre_wallet_ledger.md
+++ b/docs/especificacao_payments_module_pix_sobre_wallet_ledger.md
@@ -1,0 +1,321 @@
+# Especificação — Payments Module (Pix) sobre Wallet + Ledger
+
+> Objetivo: especificar a implementação do **módulo Payments** (cash-in e cash-out via Pix) como camada de integração externa e orquestração de estados, usando **Wallet** (contas/produto) e **Ledger** (lançamentos imutáveis), **sem modificar o Ledger Core**.
+
+Este documento é orientado a implementação (Codex/dev), com requisitos funcionais, modelo de dados, APIs, fluxos, idempotência, segurança de webhooks e integração com PSP.
+
+---
+
+## 1. Escopo
+
+### Em escopo (MVP)
+- Pix **cash-in** via PSP (criar cobrança/QR, receber confirmação via webhook)
+- Pix **cash-out** (payout) via PSP (solicitar envio, receber confirmação via webhook)
+- Estados do pagamento: `PENDING`, `CONFIRMED`, `FAILED`, `CANCELED`
+- Idempotência end-to-end por tenant
+- Integração Payments → Wallet (créditos/débitos) usando transferências internas
+- Segurança: verificação de assinatura do webhook do PSP
+- Observabilidade: `traceId` e logs estruturados
+
+### Fora de escopo (MVP)
+- Chargeback/disputas
+- Boleto/cartão
+- Split automático (fica no módulo de domínio)
+- Conciliação bancária completa (apenas base)
+
+---
+
+## 2. Arquitetura e Responsabilidades
+
+- **Ledger**: registra `LedgerTransaction` e `Entries` (imutável) e calcula saldo.
+- **Wallet**: expõe `WalletAccount` e `POST /transfers` (interno) para movimentar saldo entre contas.
+- **Payments**: fala com PSP, mantém o **estado** do pagamento e decide **quando** lançar no Wallet/Ledger (somente após confirmação).
+
+Fluxo alto nível:
+
+```
+Client (domain/app)
+   │
+   ▼
+Payments API  ──► PSP API
+   │              │
+   │              └──► Webhook (CONFIRMED/FAILED)
+   ▼
+Wallet (transfers) ──► Ledger (entries)
+```
+
+---
+
+## 3. Modelo de Dados (Payments)
+
+### 3.1 Payment (abstrato)
+Tabela: `payments`
+
+Campos:
+- `id` (UUID)
+- `tenant_id` (UUID)
+- `type` (`PIX_CASHIN`, `PIX_PAYOUT`)
+- `status` (`PENDING`, `CONFIRMED`, `FAILED`, `CANCELED`)
+- `amount_minor` (long)
+- `currency` (string, ex: BRL)
+- `reference_type` (string) — ex: `PLATFORM_TRANSACTION`, `SETTLEMENT`, `ORDER`
+- `reference_id` (string)
+- `idempotency_key` (string)
+- `external_provider` (string, ex: `ASAAS`, `PAGARME`)
+- `external_payment_id` (string)
+- `external_txid` (string) — no caso Pix
+- `created_at`, `updated_at`
+- `confirmed_at` (nullable)
+- `failure_reason` (nullable)
+- `wallet_from_account_id` (UUID, nullable)
+- `wallet_to_account_id` (UUID, nullable)
+- `ledger_transaction_id` (UUID, nullable) — opcional se wallet retorna
+
+Constraints/Índices:
+- UNIQUE (`tenant_id`, `idempotency_key`)
+- INDEX (`tenant_id`, `reference_type`, `reference_id`)
+- INDEX (`tenant_id`, `external_payment_id`)
+
+> Observação: `wallet_from_account_id`/`wallet_to_account_id` são IDs de **WalletAccount** (não ledger).
+
+---
+
+## 4. Contas Internas (Wallet) usadas por Payments
+
+Por tenant, deve existir (criada sob demanda):
+
+- `CASH_AT_PSP` (INTERNAL): representa o “caixa real”/saldo no PSP/banco (conceitual para conciliação)
+- `OUTBOUND_CLEARING` (INTERNAL): conta de compensação para payouts (recomendado)
+
+A criação dessas contas segue a regra da Wallet:
+- `POST /accounts` com `ownerType=INTERNAL` e `ownerId` fixos
+
+---
+
+## 5. Requisitos Funcionais
+
+### RF-PAY-01 — Criar cobrança Pix (Cash-in)
+Endpoint:
+- `POST /payments/pix/charges`
+
+Headers:
+- `X-API-Key`
+- `Idempotency-Key` (opcional; se não vier, usar `reference_id` como base)
+
+Request:
+```json
+{
+  "referenceType": "PLATFORM_TRANSACTION",
+  "referenceId": "txn-123",
+  "amountMinor": 12000,
+  "currency": "BRL",
+  "payer": {
+    "name": "João",
+    "document": "12345678900"
+  },
+  "creditToWalletAccountId": "wallet-account-uuid"
+}
+```
+
+Comportamento:
+1. Resolver `tenantId`.
+2. Persistir `Payment` com `type=PIX_CASHIN`, `status=PENDING`.
+3. Chamar PSP para criar cobrança Pix e obter QR/copia-e-cola + `externalPaymentId` + `txid`.
+4. Atualizar Payment com dados externos.
+5. Retornar payload para pagamento.
+
+Response:
+```json
+{
+  "paymentId": "uuid",
+  "status": "PENDING",
+  "externalPaymentId": "...",
+  "txid": "...",
+  "qrCode": "<base64 ou url>",
+  "copyPaste": "000201...",
+  "expiresAt": "..."
+}
+```
+
+---
+
+### RF-PAY-02 — Confirmar cobrança via Webhook (Cash-in)
+Endpoint:
+- `POST /payments/webhooks/psp`
+
+Regras:
+- Validar assinatura do webhook (ver seção 7).
+- Resolver `tenantId` por configuração do PSP (não via API key).
+- Idempotência: processar evento uma vez por `externalPaymentId + eventType`.
+
+Ao receber confirmação:
+1. Carregar `Payment` pelo `externalPaymentId`.
+2. Se já `CONFIRMED`, retornar 200.
+3. Marcar `CONFIRMED`.
+4. Executar crédito na Wallet usando transferência interna:
+   - `CASH_AT_PSP` → `creditToWalletAccountId`
+   - usar `idempotencyKey` derivada do payment (ex: `pay_<paymentId>_confirm`)
+5. Registrar `ledger_transaction_id` se disponível.
+
+---
+
+### RF-PAY-03 — Solicitar payout Pix (Cash-out)
+Endpoint:
+- `POST /payments/pix/payouts`
+
+Request:
+```json
+{
+  "referenceType": "SETTLEMENT",
+  "referenceId": "settlement-456",
+  "amountMinor": 50000,
+  "currency": "BRL",
+  "pixKey": "user@email.com",
+  "debitFromWalletAccountId": "wallet-account-uuid",
+  "description": "Payout"
+}
+```
+
+Comportamento (recomendado com clearing):
+1. Resolver `tenantId`.
+2. Validar saldo suficiente no `debitFromWalletAccountId`.
+3. Criar `Payment` `PIX_PAYOUT` com `PENDING`.
+4. Movimentar saldo para clearing (reserva):
+   - `debitFromWalletAccountId` → `OUTBOUND_CLEARING`
+5. Chamar PSP para enviar Pix.
+6. Salvar `externalPaymentId`.
+
+Response:
+```json
+{
+  "paymentId": "uuid",
+  "status": "PENDING",
+  "externalPaymentId": "..."
+}
+```
+
+---
+
+### RF-PAY-04 — Confirmar payout via Webhook
+Ao receber evento do PSP:
+
+**CONFIRMED**
+1. Marcar payment `CONFIRMED`.
+2. Baixar clearing:
+   - `OUTBOUND_CLEARING` → `CASH_AT_PSP`
+
+**FAILED/CANCELED**
+1. Marcar payment `FAILED` ou `CANCELED`.
+2. Estornar a reserva:
+   - `OUTBOUND_CLEARING` → `debitFromWalletAccountId`
+
+Tudo com idempotência.
+
+---
+
+### RF-PAY-05 — Consultar payment
+Endpoints:
+- `GET /payments/{paymentId}`
+- `GET /payments/by-reference?referenceType=...&referenceId=...`
+
+Resposta deve incluir status e informações externas principais.
+
+---
+
+## 6. Requisitos Não Funcionais
+
+- **Imutabilidade**: Payments nunca altera o Ledger diretamente; sempre via Wallet transfers.
+- **Atomicidade**:
+  - Atualização de `Payment.status` + criação de transfer devem ser consistentes.
+  - Preferir transação DB local + idempotência no Wallet.
+- **Idempotência**:
+  - `payments(tenant_id, idempotency_key)`
+  - webhook dedup por `externalPaymentId` e `eventType`
+- **Observabilidade**:
+  - `traceId` em logs, responses e propagação para chamadas ao PSP.
+- **Erros padronizados**:
+  - seguir ADR de Problem Details (400/401/404/409/500).
+
+---
+
+## 7. Segurança de Webhooks
+
+Implementar validação de autenticidade do webhook:
+
+Opções:
+1) **HMAC signature** (recomendado):
+- PSP envia header `X-Signature`.
+- Seu sistema calcula HMAC SHA-256 do body com secret do tenant/psp.
+- Compara de forma segura (timing-safe).
+
+2) **mTLS** (se disponível) — fora do MVP.
+
+Regras:
+- Rejeitar webhooks sem assinatura válida (401/403).
+- Logar `traceId`, `externalPaymentId`, `eventType`.
+
+---
+
+## 8. Integração com PSP (Adapter)
+
+Criar interface:
+
+- `PixProviderClient`
+  - `createCharge(CreateChargeParams) -> ChargeCreated`
+  - `createPayout(CreatePayoutParams) -> PayoutCreated`
+  - (opcional) `getChargeStatus(txid)`
+
+Implementar um adapter real (PSP escolhido) e um stub/fake para testes.
+
+Configuração:
+- `payments.provider = ASAAS | PAGARME | ...`
+- credenciais por tenant (futuro). No MVP pode ser global.
+
+---
+
+## 9. APIs (Contrato)
+
+### 9.1 POST /payments/pix/charges
+- cria cobrança e retorna QR
+
+### 9.2 POST /payments/pix/payouts
+- solicita payout e reserva saldo
+
+### 9.3 POST /payments/webhooks/psp
+- recebe eventos e consolida no Wallet
+
+### 9.4 GET /payments/{id}
+- consulta status
+
+---
+
+## 10. Testes (mínimos)
+
+### Integração
+1. Criar charge → retorna PENDING + QR
+2. Webhook CONFIRMED → saldo da Wallet aumenta
+3. Criar payout → reserva em OUTBOUND_CLEARING
+4. Webhook FAILED → saldo volta para Wallet
+5. Webhook CONFIRMED → baixa clearing e mantém débito
+
+### Contrato de erro
+- Enum/currency inválidos → 400 com violations
+- Saldo insuficiente no payout → 409 ou 422 (decidir) com errorCode
+- Webhook assinatura inválida → 401/403
+
+---
+
+## 11. Backlog de Implementação (ordem sugerida)
+
+1) Modelos/tabelas `payments`
+2) Interface `PixProviderClient` + Fake
+3) Endpoints charges/payouts (PENDING)
+4) Contas internas `CASH_AT_PSP` e `OUTBOUND_CLEARING` (criar sob demanda via Wallet)
+5) Webhook + assinatura + idempotência
+6) Integração com Wallet transfers
+7) Testes E2E
+
+---
+
+**Fim da Especificação — Payments Module (Pix) sobre Wallet + Ledger**
+

--- a/src/main/java/com/sistema/payments/api/PaymentsResource.java
+++ b/src/main/java/com/sistema/payments/api/PaymentsResource.java
@@ -1,0 +1,210 @@
+package com.sistema.payments.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sistema.common.tenant.TenantResolver;
+import com.sistema.payments.api.dto.CreatePixChargeRequest;
+import com.sistema.payments.api.dto.CreatePixChargeResponse;
+import com.sistema.payments.api.dto.CreatePixPayoutRequest;
+import com.sistema.payments.api.dto.CreatePixPayoutResponse;
+import com.sistema.payments.api.dto.PaymentResponse;
+import com.sistema.payments.application.CreatePixChargeUseCase;
+import com.sistema.payments.application.CreatePixPayoutUseCase;
+import com.sistema.payments.application.GetPaymentByReferenceUseCase;
+import com.sistema.payments.application.GetPaymentUseCase;
+import com.sistema.payments.application.ProcessPspWebhookUseCase;
+import com.sistema.payments.application.WebhookSignatureValidator;
+import com.sistema.payments.application.command.CreatePixChargeCommand;
+import com.sistema.payments.application.command.CreatePixPayoutCommand;
+import com.sistema.payments.application.exception.PaymentsUnauthorizedException;
+import com.sistema.payments.application.exception.PaymentsWebhookUnauthorizedException;
+import com.sistema.payments.application.model.PspWebhookEvent;
+import com.sistema.payments.domain.model.Payment;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Path("/payments")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PaymentsResource {
+    @Inject
+    TenantResolver tenantResolver;
+
+    @Inject
+    CreatePixChargeUseCase createPixChargeUseCase;
+
+    @Inject
+    CreatePixPayoutUseCase createPixPayoutUseCase;
+
+    @Inject
+    ProcessPspWebhookUseCase processPspWebhookUseCase;
+
+    @Inject
+    GetPaymentUseCase getPaymentUseCase;
+
+    @Inject
+    GetPaymentByReferenceUseCase getPaymentByReferenceUseCase;
+
+    @Inject
+    WebhookSignatureValidator signatureValidator;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @POST
+    @Path("/pix/charges")
+    public Response createCharge(@HeaderParam("X-API-Key") String apiKey,
+                                 @HeaderParam("Idempotency-Key") String idempotencyKey,
+                                 @Valid CreatePixChargeRequest request) {
+        UUID tenantId = requireTenantId(apiKey);
+        String resolvedIdempotency = resolveIdempotencyKey(idempotencyKey, request.getReferenceId());
+        var command = new CreatePixChargeCommand(
+                request.getReferenceType(),
+                request.getReferenceId(),
+                request.getAmountMinor(),
+                request.getCurrency(),
+                request.getPayer().getName(),
+                request.getPayer().getDocument(),
+                request.getCreditToWalletAccountId(),
+                resolvedIdempotency
+        );
+        var result = createPixChargeUseCase.execute(tenantId, command);
+        CreatePixChargeResponse response = new CreatePixChargeResponse();
+        response.setPaymentId(result.getPaymentId().toString());
+        response.setStatus(result.getStatus());
+        response.setExternalPaymentId(result.getExternalPaymentId());
+        response.setTxid(result.getTxid());
+        response.setQrCode(result.getQrCode());
+        response.setCopyPaste(result.getCopyPaste());
+        response.setExpiresAt(result.getExpiresAt());
+        return Response.status(Response.Status.CREATED).entity(response).build();
+    }
+
+    @POST
+    @Path("/pix/payouts")
+    public Response createPayout(@HeaderParam("X-API-Key") String apiKey,
+                                 @HeaderParam("Idempotency-Key") String idempotencyKey,
+                                 @Valid CreatePixPayoutRequest request) {
+        UUID tenantId = requireTenantId(apiKey);
+        String resolvedIdempotency = resolveIdempotencyKey(idempotencyKey, request.getReferenceId());
+        var command = new CreatePixPayoutCommand(
+                request.getReferenceType(),
+                request.getReferenceId(),
+                request.getAmountMinor(),
+                request.getCurrency(),
+                request.getPixKey(),
+                request.getDebitFromWalletAccountId(),
+                request.getDescription(),
+                resolvedIdempotency
+        );
+        var result = createPixPayoutUseCase.execute(tenantId, command);
+        CreatePixPayoutResponse response = new CreatePixPayoutResponse();
+        response.setPaymentId(result.getPaymentId().toString());
+        response.setStatus(result.getStatus());
+        response.setExternalPaymentId(result.getExternalPaymentId());
+        return Response.status(Response.Status.CREATED).entity(response).build();
+    }
+
+    @POST
+    @Path("/webhooks/psp")
+    public Response processWebhook(@HeaderParam("X-Signature") String signature,
+                                   String rawBody) {
+        String body = rawBody == null ? "" : rawBody;
+        if (!signatureValidator.isValid(signature, body)) {
+            throw new PaymentsWebhookUnauthorizedException("invalid webhook signature");
+        }
+        PspWebhookEvent event = parseWebhookEvent(body);
+        processPspWebhookUseCase.execute(event);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/{paymentId}")
+    public PaymentResponse getPayment(@HeaderParam("X-API-Key") String apiKey,
+                                      @PathParam("paymentId") String paymentId) {
+        UUID tenantId = requireTenantId(apiKey);
+        Payment payment = getPaymentUseCase.execute(tenantId, parsePaymentId(paymentId));
+        return toResponse(payment);
+    }
+
+    @GET
+    @Path("/by-reference")
+    public PaymentResponse getPaymentByReference(@HeaderParam("X-API-Key") String apiKey,
+                                                 @QueryParam("referenceType") String referenceType,
+                                                 @QueryParam("referenceId") String referenceId) {
+        UUID tenantId = requireTenantId(apiKey);
+        if (referenceType == null || referenceType.isBlank()) {
+            throw new IllegalArgumentException("referenceType is required");
+        }
+        if (referenceId == null || referenceId.isBlank()) {
+            throw new IllegalArgumentException("referenceId is required");
+        }
+        Payment payment = getPaymentByReferenceUseCase.execute(tenantId, referenceType, referenceId);
+        return toResponse(payment);
+    }
+
+    private UUID requireTenantId(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new PaymentsUnauthorizedException("apiKey is required");
+        }
+        return tenantResolver.resolveTenantId(apiKey)
+                .orElseThrow(() -> new PaymentsUnauthorizedException("apiKey not recognized"));
+    }
+
+    private UUID parsePaymentId(String paymentId) {
+        try {
+            return UUID.fromString(paymentId);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("paymentId must be a valid UUID");
+        }
+    }
+
+    private String resolveIdempotencyKey(String idempotencyKey, String referenceId) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            return referenceId;
+        }
+        return idempotencyKey;
+    }
+
+    private PspWebhookEvent parseWebhookEvent(String rawBody) {
+        try {
+            return objectMapper.readValue(rawBody, PspWebhookEvent.class);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("invalid webhook payload");
+        }
+    }
+
+    private PaymentResponse toResponse(Payment payment) {
+        PaymentResponse response = new PaymentResponse();
+        response.setPaymentId(payment.getId().toString());
+        response.setStatus(payment.getStatus().name());
+        response.setType(payment.getType().name());
+        response.setAmountMinor(payment.getAmountMinor());
+        response.setCurrency(payment.getCurrency());
+        response.setReferenceType(payment.getReferenceType());
+        response.setReferenceId(payment.getReferenceId());
+        response.setExternalProvider(payment.getExternalProvider());
+        response.setExternalPaymentId(payment.getExternalPaymentId());
+        response.setTxid(payment.getExternalTxid());
+        response.setCreatedAt(payment.getCreatedAt());
+        response.setUpdatedAt(payment.getUpdatedAt());
+        response.setConfirmedAt(payment.getConfirmedAt());
+        response.setFailureReason(payment.getFailureReason());
+        response.setWalletFromAccountId(payment.getWalletFromAccountId() == null ? null : payment.getWalletFromAccountId().toString());
+        response.setWalletToAccountId(payment.getWalletToAccountId() == null ? null : payment.getWalletToAccountId().toString());
+        response.setLedgerTransactionId(payment.getLedgerTransactionId() == null ? null : payment.getLedgerTransactionId().toString());
+        return response;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/CreatePixChargeRequest.java
+++ b/src/main/java/com/sistema/payments/api/dto/CreatePixChargeRequest.java
@@ -1,0 +1,79 @@
+package com.sistema.payments.api.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public class CreatePixChargeRequest {
+    @NotBlank(message = "referenceType is required")
+    private String referenceType;
+
+    @NotBlank(message = "referenceId is required")
+    private String referenceId;
+
+    @Positive(message = "amountMinor must be greater than zero")
+    private long amountMinor;
+
+    @NotBlank(message = "currency is required")
+    @Pattern(regexp = "^[A-Z]{3}$", message = "currency must be a 3-letter ISO code")
+    private String currency;
+
+    @Valid
+    @NotNull(message = "payer is required")
+    private PayerRequest payer;
+
+    @NotBlank(message = "creditToWalletAccountId is required")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            message = "creditToWalletAccountId must be a valid UUID")
+    private String creditToWalletAccountId;
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public PayerRequest getPayer() {
+        return payer;
+    }
+
+    public void setPayer(PayerRequest payer) {
+        this.payer = payer;
+    }
+
+    public String getCreditToWalletAccountId() {
+        return creditToWalletAccountId;
+    }
+
+    public void setCreditToWalletAccountId(String creditToWalletAccountId) {
+        this.creditToWalletAccountId = creditToWalletAccountId;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/CreatePixChargeResponse.java
+++ b/src/main/java/com/sistema/payments/api/dto/CreatePixChargeResponse.java
@@ -1,0 +1,69 @@
+package com.sistema.payments.api.dto;
+
+import java.time.Instant;
+
+public class CreatePixChargeResponse {
+    private String paymentId;
+    private String status;
+    private String externalPaymentId;
+    private String txid;
+    private String qrCode;
+    private String copyPaste;
+    private Instant expiresAt;
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+
+    public void setPaymentId(String paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getTxid() {
+        return txid;
+    }
+
+    public void setTxid(String txid) {
+        this.txid = txid;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public String getCopyPaste() {
+        return copyPaste;
+    }
+
+    public void setCopyPaste(String copyPaste) {
+        this.copyPaste = copyPaste;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/CreatePixPayoutRequest.java
+++ b/src/main/java/com/sistema/payments/api/dto/CreatePixPayoutRequest.java
@@ -1,0 +1,86 @@
+package com.sistema.payments.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public class CreatePixPayoutRequest {
+    @NotBlank(message = "referenceType is required")
+    private String referenceType;
+
+    @NotBlank(message = "referenceId is required")
+    private String referenceId;
+
+    @Positive(message = "amountMinor must be greater than zero")
+    private long amountMinor;
+
+    @NotBlank(message = "currency is required")
+    @Pattern(regexp = "^[A-Z]{3}$", message = "currency must be a 3-letter ISO code")
+    private String currency;
+
+    @NotBlank(message = "pixKey is required")
+    private String pixKey;
+
+    @NotBlank(message = "debitFromWalletAccountId is required")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            message = "debitFromWalletAccountId must be a valid UUID")
+    private String debitFromWalletAccountId;
+
+    private String description;
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getPixKey() {
+        return pixKey;
+    }
+
+    public void setPixKey(String pixKey) {
+        this.pixKey = pixKey;
+    }
+
+    public String getDebitFromWalletAccountId() {
+        return debitFromWalletAccountId;
+    }
+
+    public void setDebitFromWalletAccountId(String debitFromWalletAccountId) {
+        this.debitFromWalletAccountId = debitFromWalletAccountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/CreatePixPayoutResponse.java
+++ b/src/main/java/com/sistema/payments/api/dto/CreatePixPayoutResponse.java
@@ -1,0 +1,31 @@
+package com.sistema.payments.api.dto;
+
+public class CreatePixPayoutResponse {
+    private String paymentId;
+    private String status;
+    private String externalPaymentId;
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+
+    public void setPaymentId(String paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/PayerRequest.java
+++ b/src/main/java/com/sistema/payments/api/dto/PayerRequest.java
@@ -1,0 +1,27 @@
+package com.sistema.payments.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class PayerRequest {
+    @NotBlank(message = "payer.name is required")
+    private String name;
+
+    @NotBlank(message = "payer.document is required")
+    private String document;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDocument() {
+        return document;
+    }
+
+    public void setDocument(String document) {
+        this.document = document;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/dto/PaymentResponse.java
+++ b/src/main/java/com/sistema/payments/api/dto/PaymentResponse.java
@@ -1,0 +1,159 @@
+package com.sistema.payments.api.dto;
+
+import java.time.Instant;
+
+public class PaymentResponse {
+    private String paymentId;
+    private String status;
+    private String type;
+    private long amountMinor;
+    private String currency;
+    private String referenceType;
+    private String referenceId;
+    private String externalProvider;
+    private String externalPaymentId;
+    private String txid;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant confirmedAt;
+    private String failureReason;
+    private String walletFromAccountId;
+    private String walletToAccountId;
+    private String ledgerTransactionId;
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+
+    public void setPaymentId(String paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public String getExternalProvider() {
+        return externalProvider;
+    }
+
+    public void setExternalProvider(String externalProvider) {
+        this.externalProvider = externalProvider;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getTxid() {
+        return txid;
+    }
+
+    public void setTxid(String txid) {
+        this.txid = txid;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Instant getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(Instant confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getWalletFromAccountId() {
+        return walletFromAccountId;
+    }
+
+    public void setWalletFromAccountId(String walletFromAccountId) {
+        this.walletFromAccountId = walletFromAccountId;
+    }
+
+    public String getWalletToAccountId() {
+        return walletToAccountId;
+    }
+
+    public void setWalletToAccountId(String walletToAccountId) {
+        this.walletToAccountId = walletToAccountId;
+    }
+
+    public String getLedgerTransactionId() {
+        return ledgerTransactionId;
+    }
+
+    public void setLedgerTransactionId(String ledgerTransactionId) {
+        this.ledgerTransactionId = ledgerTransactionId;
+    }
+}

--- a/src/main/java/com/sistema/payments/api/error/PaymentsErrorCodes.java
+++ b/src/main/java/com/sistema/payments/api/error/PaymentsErrorCodes.java
@@ -1,0 +1,15 @@
+package com.sistema.payments.api.error;
+
+public final class PaymentsErrorCodes {
+    public static final String PAYMENTS_UNAUTHORIZED = "PAYMENTS_UNAUTHORIZED";
+    public static final String PAYMENTS_WEBHOOK_UNAUTHORIZED = "PAYMENTS_WEBHOOK_UNAUTHORIZED";
+    public static final String PAYMENTS_NOT_FOUND = "PAYMENTS_NOT_FOUND";
+    public static final String PAYMENTS_IDEMPOTENCY_CONFLICT = "PAYMENTS_IDEMPOTENCY_CONFLICT";
+    public static final String PAYMENTS_INVALID_STATE = "PAYMENTS_INVALID_STATE";
+    public static final String PAYMENTS_INSUFFICIENT_BALANCE = "PAYMENTS_INSUFFICIENT_BALANCE";
+    public static final String PAYMENTS_PROVIDER_ERROR = "PAYMENTS_PROVIDER_ERROR";
+    public static final String PAYMENTS_INTERNAL_ERROR = "PAYMENTS_INTERNAL_ERROR";
+
+    private PaymentsErrorCodes() {
+    }
+}

--- a/src/main/java/com/sistema/payments/api/error/PaymentsExceptionMapper.java
+++ b/src/main/java/com/sistema/payments/api/error/PaymentsExceptionMapper.java
@@ -1,0 +1,59 @@
+package com.sistema.payments.api.error;
+
+import com.sistema.common.api.error.CommonErrorTypes;
+import com.sistema.common.api.error.ErrorResponse;
+import com.sistema.common.api.error.ErrorResponseFactory;
+import com.sistema.common.api.trace.TraceIdProvider;
+import com.sistema.payments.application.exception.PaymentsException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class PaymentsExceptionMapper implements ExceptionMapper<PaymentsException> {
+    @Context
+    UriInfo uriInfo;
+
+    @Inject
+    TraceIdProvider traceIdProvider;
+
+    @Override
+    public Response toResponse(PaymentsException exception) {
+        int status = exception.getStatus();
+        String type = mapType(status);
+        String title = mapTitle(status);
+        ErrorResponse response = ErrorResponseFactory.build(
+                type,
+                title,
+                status,
+                exception.getMessage(),
+                ErrorResponseFactory.resolveInstance(uriInfo),
+                exception.getErrorCode(),
+                null,
+                exception.getMeta(),
+                traceIdProvider
+        );
+        return Response.status(status).entity(response).build();
+    }
+
+    private String mapType(int status) {
+        return switch (status) {
+            case 401 -> CommonErrorTypes.UNAUTHORIZED;
+            case 404 -> CommonErrorTypes.NOT_FOUND;
+            case 409 -> CommonErrorTypes.CONFLICT;
+            default -> CommonErrorTypes.INTERNAL;
+        };
+    }
+
+    private String mapTitle(int status) {
+        return switch (status) {
+            case 401 -> "Unauthorized";
+            case 404 -> "Not found";
+            case 409 -> "Conflict";
+            default -> "Error";
+        };
+    }
+}

--- a/src/main/java/com/sistema/payments/application/CreatePixChargeUseCase.java
+++ b/src/main/java/com/sistema/payments/application/CreatePixChargeUseCase.java
@@ -1,0 +1,126 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.command.CreatePixChargeCommand;
+import com.sistema.payments.application.exception.PaymentsNotFoundException;
+import com.sistema.payments.application.exception.PaymentsProviderException;
+import com.sistema.payments.application.model.PixChargeResult;
+import com.sistema.payments.application.provider.ChargeCreated;
+import com.sistema.payments.application.provider.CreateChargeParams;
+import com.sistema.payments.application.provider.PixProviderClient;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CreatePixChargeUseCase {
+    private final PaymentRepository paymentRepository;
+    private final WalletAccountRepository walletAccountRepository;
+    private final PaymentsWalletAccountsService walletAccountsService;
+    private final PixProviderClient pixProviderClient;
+    private final String providerName;
+
+    public CreatePixChargeUseCase(PaymentRepository paymentRepository,
+                                  WalletAccountRepository walletAccountRepository,
+                                  PaymentsWalletAccountsService walletAccountsService,
+                                  PixProviderClient pixProviderClient,
+                                  @ConfigProperty(name = "payments.provider", defaultValue = "FAKE") String providerName) {
+        this.paymentRepository = paymentRepository;
+        this.walletAccountRepository = walletAccountRepository;
+        this.walletAccountsService = walletAccountsService;
+        this.pixProviderClient = pixProviderClient;
+        this.providerName = providerName;
+    }
+
+    @Transactional
+    public PixChargeResult execute(UUID tenantId, CreatePixChargeCommand command) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(command, "command");
+
+        Payment existing = paymentRepository.findByIdempotencyKey(tenantId, command.getIdempotencyKey())
+                .orElse(null);
+        if (existing != null) {
+            return new PixChargeResult(
+                    existing.getId(),
+                    existing.getStatus().name(),
+                    existing.getExternalPaymentId(),
+                    existing.getExternalTxid(),
+                    existing.getQrCode(),
+                    existing.getCopyPaste(),
+                    existing.getExpiresAt()
+            );
+        }
+
+        UUID creditAccountId = UUID.fromString(command.getCreditToWalletAccountId());
+        walletAccountRepository.findById(tenantId, creditAccountId)
+                .orElseThrow(() -> new PaymentsNotFoundException("wallet account not found"));
+
+        var cashAccount = walletAccountsService.getOrCreateCashAtPsp(tenantId, command.getCurrency());
+
+        Instant now = Instant.now();
+        Payment payment = new Payment(
+                UUID.randomUUID(),
+                tenantId,
+                PaymentType.PIX_CASHIN,
+                PaymentStatus.PENDING,
+                command.getAmountMinor(),
+                command.getCurrency(),
+                command.getReferenceType(),
+                command.getReferenceId(),
+                command.getIdempotencyKey(),
+                providerName,
+                null,
+                null,
+                null,
+                null,
+                null,
+                now,
+                now,
+                null,
+                null,
+                cashAccount.getId(),
+                creditAccountId,
+                null
+        );
+        paymentRepository.save(payment);
+
+        ChargeCreated created;
+        try {
+            created = pixProviderClient.createCharge(new CreateChargeParams(
+                    command.getReferenceId(),
+                    command.getAmountMinor(),
+                    command.getCurrency(),
+                    command.getPayerName(),
+                    command.getPayerDocument()
+            ));
+        } catch (RuntimeException ex) {
+            throw new PaymentsProviderException("failed to create pix charge");
+        }
+
+        payment.setExternalPaymentId(created.getExternalPaymentId());
+        payment.setExternalTxid(created.getTxid());
+        payment.setQrCode(created.getQrCode());
+        payment.setCopyPaste(created.getCopyPaste());
+        payment.setExpiresAt(created.getExpiresAt());
+        payment.setUpdatedAt(Instant.now());
+        paymentRepository.save(payment);
+
+        return new PixChargeResult(
+                payment.getId(),
+                payment.getStatus().name(),
+                created.getExternalPaymentId(),
+                created.getTxid(),
+                created.getQrCode(),
+                created.getCopyPaste(),
+                created.getExpiresAt()
+        );
+    }
+}

--- a/src/main/java/com/sistema/payments/application/CreatePixPayoutUseCase.java
+++ b/src/main/java/com/sistema/payments/application/CreatePixPayoutUseCase.java
@@ -1,0 +1,129 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.command.CreatePixPayoutCommand;
+import com.sistema.payments.application.exception.PaymentsInsufficientBalanceException;
+import com.sistema.payments.application.exception.PaymentsNotFoundException;
+import com.sistema.payments.application.exception.PaymentsProviderException;
+import com.sistema.payments.application.model.PixPayoutResult;
+import com.sistema.payments.application.provider.CreatePayoutParams;
+import com.sistema.payments.application.provider.PayoutCreated;
+import com.sistema.payments.application.provider.PixProviderClient;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.exception.WalletInsufficientBalanceException;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CreatePixPayoutUseCase {
+    private final PaymentRepository paymentRepository;
+    private final WalletAccountRepository walletAccountRepository;
+    private final PaymentsWalletAccountsService walletAccountsService;
+    private final TransferBetweenWalletAccountsUseCase transferUseCase;
+    private final PixProviderClient pixProviderClient;
+    private final String providerName;
+
+    public CreatePixPayoutUseCase(PaymentRepository paymentRepository,
+                                  WalletAccountRepository walletAccountRepository,
+                                  PaymentsWalletAccountsService walletAccountsService,
+                                  TransferBetweenWalletAccountsUseCase transferUseCase,
+                                  PixProviderClient pixProviderClient,
+                                  @ConfigProperty(name = "payments.provider", defaultValue = "FAKE") String providerName) {
+        this.paymentRepository = paymentRepository;
+        this.walletAccountRepository = walletAccountRepository;
+        this.walletAccountsService = walletAccountsService;
+        this.transferUseCase = transferUseCase;
+        this.pixProviderClient = pixProviderClient;
+        this.providerName = providerName;
+    }
+
+    @Transactional
+    public PixPayoutResult execute(UUID tenantId, CreatePixPayoutCommand command) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(command, "command");
+
+        Payment existing = paymentRepository.findByIdempotencyKey(tenantId, command.getIdempotencyKey())
+                .orElse(null);
+        if (existing != null) {
+            return new PixPayoutResult(existing.getId(), existing.getStatus().name(), existing.getExternalPaymentId());
+        }
+
+        UUID debitAccountId = UUID.fromString(command.getDebitFromWalletAccountId());
+        var debitAccount = walletAccountRepository.findById(tenantId, debitAccountId)
+                .orElseThrow(() -> new PaymentsNotFoundException("wallet account not found"));
+        if (!debitAccount.getCurrency().equals(command.getCurrency())) {
+            throw new IllegalArgumentException("currency mismatch");
+        }
+
+        var clearingAccount = walletAccountsService.getOrCreateOutboundClearing(tenantId, command.getCurrency());
+
+        Instant now = Instant.now();
+        Payment payment = new Payment(
+                UUID.randomUUID(),
+                tenantId,
+                PaymentType.PIX_PAYOUT,
+                PaymentStatus.PENDING,
+                command.getAmountMinor(),
+                command.getCurrency(),
+                command.getReferenceType(),
+                command.getReferenceId(),
+                command.getIdempotencyKey(),
+                providerName,
+                null,
+                null,
+                null,
+                null,
+                null,
+                now,
+                now,
+                null,
+                null,
+                debitAccountId,
+                clearingAccount.getId(),
+                null
+        );
+        paymentRepository.save(payment);
+
+        try {
+            transferUseCase.execute(tenantId, new TransferBetweenWalletAccountsCommand(
+                    "pay_" + payment.getId() + "_reserve",
+                    debitAccountId,
+                    clearingAccount.getId(),
+                    command.getAmountMinor(),
+                    command.getCurrency(),
+                    command.getDescription()
+            ));
+        } catch (WalletInsufficientBalanceException ex) {
+            throw new PaymentsInsufficientBalanceException(ex.getMessage());
+        }
+
+        PayoutCreated created;
+        try {
+            created = pixProviderClient.createPayout(new CreatePayoutParams(
+                    command.getReferenceId(),
+                    command.getAmountMinor(),
+                    command.getCurrency(),
+                    command.getPixKey(),
+                    command.getDescription()
+            ));
+        } catch (RuntimeException ex) {
+            throw new PaymentsProviderException("failed to create pix payout");
+        }
+
+        payment.setExternalPaymentId(created.getExternalPaymentId());
+        payment.setUpdatedAt(Instant.now());
+        paymentRepository.save(payment);
+
+        return new PixPayoutResult(payment.getId(), payment.getStatus().name(), created.getExternalPaymentId());
+    }
+}

--- a/src/main/java/com/sistema/payments/application/GetPaymentByReferenceUseCase.java
+++ b/src/main/java/com/sistema/payments/application/GetPaymentByReferenceUseCase.java
@@ -1,0 +1,26 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.exception.PaymentsNotFoundException;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class GetPaymentByReferenceUseCase {
+    private final PaymentRepository paymentRepository;
+
+    public GetPaymentByReferenceUseCase(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    public Payment execute(UUID tenantId, String referenceType, String referenceId) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(referenceType, "referenceType");
+        Objects.requireNonNull(referenceId, "referenceId");
+        return paymentRepository.findByReference(tenantId, referenceType, referenceId)
+                .orElseThrow(() -> new PaymentsNotFoundException("payment not found"));
+    }
+}

--- a/src/main/java/com/sistema/payments/application/GetPaymentUseCase.java
+++ b/src/main/java/com/sistema/payments/application/GetPaymentUseCase.java
@@ -1,0 +1,25 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.exception.PaymentsNotFoundException;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class GetPaymentUseCase {
+    private final PaymentRepository paymentRepository;
+
+    public GetPaymentUseCase(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    public Payment execute(UUID tenantId, UUID paymentId) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(paymentId, "paymentId");
+        return paymentRepository.findById(tenantId, paymentId)
+                .orElseThrow(() -> new PaymentsNotFoundException("payment not found"));
+    }
+}

--- a/src/main/java/com/sistema/payments/application/PaymentsWalletAccountsService.java
+++ b/src/main/java/com/sistema/payments/application/PaymentsWalletAccountsService.java
@@ -1,0 +1,54 @@
+package com.sistema.payments.application;
+
+import com.sistema.wallet.application.CreateWalletAccountUseCase;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.application.exception.WalletAccountAlreadyExistsException;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class PaymentsWalletAccountsService {
+    public static final String CASH_AT_PSP_OWNER_ID = "CASH_AT_PSP";
+    public static final String OUTBOUND_CLEARING_OWNER_ID = "OUTBOUND_CLEARING";
+
+    private final WalletAccountRepository walletAccountRepository;
+    private final CreateWalletAccountUseCase createWalletAccountUseCase;
+
+    public PaymentsWalletAccountsService(WalletAccountRepository walletAccountRepository,
+                                         CreateWalletAccountUseCase createWalletAccountUseCase) {
+        this.walletAccountRepository = walletAccountRepository;
+        this.createWalletAccountUseCase = createWalletAccountUseCase;
+    }
+
+    public WalletAccount getOrCreateCashAtPsp(UUID tenantId, String currency) {
+        return getOrCreate(tenantId, WalletOwnerType.FUNDING, CASH_AT_PSP_OWNER_ID, currency, "Cash at PSP");
+    }
+
+    public WalletAccount getOrCreateOutboundClearing(UUID tenantId, String currency) {
+        return getOrCreate(tenantId, WalletOwnerType.INTERNAL, OUTBOUND_CLEARING_OWNER_ID, currency, "Outbound Clearing");
+    }
+
+    private WalletAccount getOrCreate(UUID tenantId, WalletOwnerType ownerType, String ownerId, String currency, String label) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(currency, "currency");
+        return walletAccountRepository.findByOwner(tenantId, ownerType, ownerId, currency)
+                .orElseGet(() -> create(tenantId, ownerType, ownerId, currency, label));
+    }
+
+    private WalletAccount create(UUID tenantId, WalletOwnerType ownerType, String ownerId, String currency, String label) {
+        try {
+            return createWalletAccountUseCase.execute(
+                    tenantId,
+                    new CreateWalletAccountCommand(ownerType, ownerId, currency, label)
+            );
+        } catch (WalletAccountAlreadyExistsException ex) {
+            return walletAccountRepository.findByOwner(tenantId, ownerType, ownerId, currency)
+                    .orElseThrow(() -> ex);
+        }
+    }
+}

--- a/src/main/java/com/sistema/payments/application/ProcessPspWebhookUseCase.java
+++ b/src/main/java/com/sistema/payments/application/ProcessPspWebhookUseCase.java
@@ -1,0 +1,140 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.exception.PaymentsInvalidStateException;
+import com.sistema.payments.application.exception.PaymentsNotFoundException;
+import com.sistema.payments.application.model.PspWebhookEvent;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.payments.domain.repository.PaymentWebhookEventRepository;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@ApplicationScoped
+public class ProcessPspWebhookUseCase {
+    private final PaymentRepository paymentRepository;
+    private final PaymentWebhookEventRepository webhookEventRepository;
+    private final PaymentsWalletAccountsService walletAccountsService;
+    private final TransferBetweenWalletAccountsUseCase transferUseCase;
+
+    public ProcessPspWebhookUseCase(PaymentRepository paymentRepository,
+                                    PaymentWebhookEventRepository webhookEventRepository,
+                                    PaymentsWalletAccountsService walletAccountsService,
+                                    TransferBetweenWalletAccountsUseCase transferUseCase) {
+        this.paymentRepository = paymentRepository;
+        this.webhookEventRepository = webhookEventRepository;
+        this.walletAccountsService = walletAccountsService;
+        this.transferUseCase = transferUseCase;
+    }
+
+    @Transactional
+    public void execute(PspWebhookEvent event) {
+        Objects.requireNonNull(event, "event");
+        if (event.getExternalPaymentId() == null || event.getExternalPaymentId().isBlank()) {
+            throw new IllegalArgumentException("externalPaymentId is required");
+        }
+        if (event.getStatus() == null || event.getStatus().isBlank()) {
+            throw new IllegalArgumentException("status is required");
+        }
+        String eventType = event.getEventType() == null ? event.getStatus() : event.getEventType();
+        String normalizedStatus = event.getStatus().toUpperCase();
+
+        Payment payment = paymentRepository.findByExternalPaymentId(event.getExternalPaymentId())
+                .orElseThrow(() -> new PaymentsNotFoundException("payment not found"));
+
+        UUID tenantId = payment.getTenantId();
+        boolean registered = webhookEventRepository.registerEvent(tenantId, event.getExternalPaymentId(), eventType, Instant.now());
+        if (!registered) {
+            return;
+        }
+
+        PaymentStatus desiredStatus = PaymentStatus.valueOf(normalizedStatus);
+        if (payment.getStatus() == PaymentStatus.CONFIRMED && desiredStatus == PaymentStatus.CONFIRMED) {
+            return;
+        }
+
+        if (payment.getType() == PaymentType.PIX_CASHIN) {
+            handleCashIn(payment, desiredStatus);
+        } else if (payment.getType() == PaymentType.PIX_PAYOUT) {
+            handlePayout(payment, desiredStatus);
+        }
+    }
+
+    private void handleCashIn(Payment payment, PaymentStatus desiredStatus) {
+        if (desiredStatus == PaymentStatus.CONFIRMED) {
+            if (payment.getStatus() == PaymentStatus.CONFIRMED) {
+                return;
+            }
+            payment.setStatus(PaymentStatus.CONFIRMED);
+            payment.setConfirmedAt(Instant.now());
+            payment.setUpdatedAt(Instant.now());
+            paymentRepository.save(payment);
+
+            var cashAccount = walletAccountsService.getOrCreateCashAtPsp(payment.getTenantId(), payment.getCurrency());
+            transferUseCase.execute(payment.getTenantId(), new TransferBetweenWalletAccountsCommand(
+                    "pay_" + payment.getId() + "_confirm",
+                    cashAccount.getId(),
+                    payment.getWalletToAccountId(),
+                    payment.getAmountMinor(),
+                    payment.getCurrency(),
+                    "Pix cash-in confirmed"
+            ));
+            return;
+        }
+
+        if (payment.getStatus() == PaymentStatus.CONFIRMED) {
+            throw new PaymentsInvalidStateException("payment already confirmed");
+        }
+        payment.setStatus(desiredStatus);
+        payment.setFailureReason(desiredStatus.name());
+        payment.setUpdatedAt(Instant.now());
+        paymentRepository.save(payment);
+    }
+
+    private void handlePayout(Payment payment, PaymentStatus desiredStatus) {
+        if (desiredStatus == PaymentStatus.CONFIRMED) {
+            if (payment.getStatus() == PaymentStatus.CONFIRMED) {
+                return;
+            }
+            payment.setStatus(PaymentStatus.CONFIRMED);
+            payment.setConfirmedAt(Instant.now());
+            payment.setUpdatedAt(Instant.now());
+            paymentRepository.save(payment);
+
+            var cashAccount = walletAccountsService.getOrCreateCashAtPsp(payment.getTenantId(), payment.getCurrency());
+            transferUseCase.execute(payment.getTenantId(), new TransferBetweenWalletAccountsCommand(
+                    "pay_" + payment.getId() + "_settle",
+                    payment.getWalletToAccountId(),
+                    cashAccount.getId(),
+                    payment.getAmountMinor(),
+                    payment.getCurrency(),
+                    "Pix payout confirmed"
+            ));
+            return;
+        }
+
+        if (payment.getStatus() == PaymentStatus.CONFIRMED) {
+            throw new PaymentsInvalidStateException("payment already confirmed");
+        }
+        payment.setStatus(desiredStatus);
+        payment.setFailureReason(desiredStatus.name());
+        payment.setUpdatedAt(Instant.now());
+        paymentRepository.save(payment);
+
+        transferUseCase.execute(payment.getTenantId(), new TransferBetweenWalletAccountsCommand(
+                "pay_" + payment.getId() + "_rollback",
+                payment.getWalletToAccountId(),
+                payment.getWalletFromAccountId(),
+                payment.getAmountMinor(),
+                payment.getCurrency(),
+                "Pix payout failed"
+        ));
+    }
+}

--- a/src/main/java/com/sistema/payments/application/WebhookSignatureValidator.java
+++ b/src/main/java/com/sistema/payments/application/WebhookSignatureValidator.java
@@ -1,0 +1,49 @@
+package com.sistema.payments.application;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+@ApplicationScoped
+public class WebhookSignatureValidator {
+    private final String secret;
+
+    public WebhookSignatureValidator(@ConfigProperty(name = "payments.webhook.secret", defaultValue = "change-me") String secret) {
+        this.secret = secret;
+    }
+
+    public boolean isValid(String signatureHeader, String body) {
+        if (signatureHeader == null || signatureHeader.isBlank()) {
+            return false;
+        }
+        String signature = signatureHeader.trim();
+        if (signature.startsWith("sha256=")) {
+            signature = signature.substring("sha256=".length());
+        }
+        String computed = hmacSha256Hex(body, secret);
+        return MessageDigest.isEqual(computed.getBytes(StandardCharsets.UTF_8), signature.toLowerCase().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String hmacSha256Hex(String body, String secretKey) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] raw = mac.doFinal(body.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(raw.length * 2);
+            for (byte b : raw) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    sb.append('0');
+                }
+                sb.append(hex);
+            }
+            return sb.toString();
+        } catch (Exception ex) {
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/sistema/payments/application/command/CreatePixChargeCommand.java
+++ b/src/main/java/com/sistema/payments/application/command/CreatePixChargeCommand.java
@@ -1,0 +1,62 @@
+package com.sistema.payments.application.command;
+
+public class CreatePixChargeCommand {
+    private final String referenceType;
+    private final String referenceId;
+    private final long amountMinor;
+    private final String currency;
+    private final String payerName;
+    private final String payerDocument;
+    private final String creditToWalletAccountId;
+    private final String idempotencyKey;
+
+    public CreatePixChargeCommand(String referenceType,
+                                  String referenceId,
+                                  long amountMinor,
+                                  String currency,
+                                  String payerName,
+                                  String payerDocument,
+                                  String creditToWalletAccountId,
+                                  String idempotencyKey) {
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.payerName = payerName;
+        this.payerDocument = payerDocument;
+        this.creditToWalletAccountId = creditToWalletAccountId;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getPayerName() {
+        return payerName;
+    }
+
+    public String getPayerDocument() {
+        return payerDocument;
+    }
+
+    public String getCreditToWalletAccountId() {
+        return creditToWalletAccountId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/command/CreatePixPayoutCommand.java
+++ b/src/main/java/com/sistema/payments/application/command/CreatePixPayoutCommand.java
@@ -1,0 +1,62 @@
+package com.sistema.payments.application.command;
+
+public class CreatePixPayoutCommand {
+    private final String referenceType;
+    private final String referenceId;
+    private final long amountMinor;
+    private final String currency;
+    private final String pixKey;
+    private final String debitFromWalletAccountId;
+    private final String description;
+    private final String idempotencyKey;
+
+    public CreatePixPayoutCommand(String referenceType,
+                                  String referenceId,
+                                  long amountMinor,
+                                  String currency,
+                                  String pixKey,
+                                  String debitFromWalletAccountId,
+                                  String description,
+                                  String idempotencyKey) {
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.pixKey = pixKey;
+        this.debitFromWalletAccountId = debitFromWalletAccountId;
+        this.description = description;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getPixKey() {
+        return pixKey;
+    }
+
+    public String getDebitFromWalletAccountId() {
+        return debitFromWalletAccountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsException.java
@@ -1,0 +1,30 @@
+package com.sistema.payments.application.exception;
+
+public abstract class PaymentsException extends RuntimeException {
+    private final int status;
+    private final String errorCode;
+    private final java.util.Map<String, Object> meta;
+
+    protected PaymentsException(String message, int status, String errorCode) {
+        this(message, status, errorCode, null);
+    }
+
+    protected PaymentsException(String message, int status, String errorCode, java.util.Map<String, Object> meta) {
+        super(message);
+        this.status = status;
+        this.errorCode = errorCode;
+        this.meta = meta;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public java.util.Map<String, Object> getMeta() {
+        return meta;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsIdempotencyConflictException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsIdempotencyConflictException.java
@@ -1,0 +1,13 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class PaymentsIdempotencyConflictException extends PaymentsException {
+    public PaymentsIdempotencyConflictException(String idempotencyKey, UUID paymentId) {
+        super("Idempotency conflict", 409, PaymentsErrorCodes.PAYMENTS_IDEMPOTENCY_CONFLICT,
+                Map.of("idempotencyKey", idempotencyKey, "paymentId", paymentId));
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsInsufficientBalanceException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsInsufficientBalanceException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsInsufficientBalanceException extends PaymentsException {
+    public PaymentsInsufficientBalanceException(String message) {
+        super(message, 409, PaymentsErrorCodes.PAYMENTS_INSUFFICIENT_BALANCE);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsInvalidStateException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsInvalidStateException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsInvalidStateException extends PaymentsException {
+    public PaymentsInvalidStateException(String message) {
+        super(message, 409, PaymentsErrorCodes.PAYMENTS_INVALID_STATE);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsNotFoundException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsNotFoundException extends PaymentsException {
+    public PaymentsNotFoundException(String message) {
+        super(message, 404, PaymentsErrorCodes.PAYMENTS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsProviderException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsProviderException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsProviderException extends PaymentsException {
+    public PaymentsProviderException(String message) {
+        super(message, 500, PaymentsErrorCodes.PAYMENTS_PROVIDER_ERROR);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsUnauthorizedException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsUnauthorizedException extends PaymentsException {
+    public PaymentsUnauthorizedException(String message) {
+        super(message, 401, PaymentsErrorCodes.PAYMENTS_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/exception/PaymentsWebhookUnauthorizedException.java
+++ b/src/main/java/com/sistema/payments/application/exception/PaymentsWebhookUnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.sistema.payments.application.exception;
+
+import com.sistema.payments.api.error.PaymentsErrorCodes;
+
+public class PaymentsWebhookUnauthorizedException extends PaymentsException {
+    public PaymentsWebhookUnauthorizedException(String message) {
+        super(message, 401, PaymentsErrorCodes.PAYMENTS_WEBHOOK_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sistema/payments/application/model/PixChargeResult.java
+++ b/src/main/java/com/sistema/payments/application/model/PixChargeResult.java
@@ -1,0 +1,58 @@
+package com.sistema.payments.application.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class PixChargeResult {
+    private final UUID paymentId;
+    private final String status;
+    private final String externalPaymentId;
+    private final String txid;
+    private final String qrCode;
+    private final String copyPaste;
+    private final Instant expiresAt;
+
+    public PixChargeResult(UUID paymentId,
+                           String status,
+                           String externalPaymentId,
+                           String txid,
+                           String qrCode,
+                           String copyPaste,
+                           Instant expiresAt) {
+        this.paymentId = paymentId;
+        this.status = status;
+        this.externalPaymentId = externalPaymentId;
+        this.txid = txid;
+        this.qrCode = qrCode;
+        this.copyPaste = copyPaste;
+        this.expiresAt = expiresAt;
+    }
+
+    public UUID getPaymentId() {
+        return paymentId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public String getTxid() {
+        return txid;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public String getCopyPaste() {
+        return copyPaste;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/model/PixPayoutResult.java
+++ b/src/main/java/com/sistema/payments/application/model/PixPayoutResult.java
@@ -1,0 +1,27 @@
+package com.sistema.payments.application.model;
+
+import java.util.UUID;
+
+public class PixPayoutResult {
+    private final UUID paymentId;
+    private final String status;
+    private final String externalPaymentId;
+
+    public PixPayoutResult(UUID paymentId, String status, String externalPaymentId) {
+        this.paymentId = paymentId;
+        this.status = status;
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public UUID getPaymentId() {
+        return paymentId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/model/PspWebhookEvent.java
+++ b/src/main/java/com/sistema/payments/application/model/PspWebhookEvent.java
@@ -1,0 +1,58 @@
+package com.sistema.payments.application.model;
+
+public class PspWebhookEvent {
+    private String externalPaymentId;
+    private String eventType;
+    private String status;
+    private String txid;
+    private Long amountMinor;
+    private String currency;
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getTxid() {
+        return txid;
+    }
+
+    public void setTxid(String txid) {
+        this.txid = txid;
+    }
+
+    public Long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(Long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/provider/ChargeCreated.java
+++ b/src/main/java/com/sistema/payments/application/provider/ChargeCreated.java
@@ -1,0 +1,43 @@
+package com.sistema.payments.application.provider;
+
+import java.time.Instant;
+
+public class ChargeCreated {
+    private final String externalPaymentId;
+    private final String txid;
+    private final String qrCode;
+    private final String copyPaste;
+    private final Instant expiresAt;
+
+    public ChargeCreated(String externalPaymentId,
+                         String txid,
+                         String qrCode,
+                         String copyPaste,
+                         Instant expiresAt) {
+        this.externalPaymentId = externalPaymentId;
+        this.txid = txid;
+        this.qrCode = qrCode;
+        this.copyPaste = copyPaste;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public String getTxid() {
+        return txid;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public String getCopyPaste() {
+        return copyPaste;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/provider/CreateChargeParams.java
+++ b/src/main/java/com/sistema/payments/application/provider/CreateChargeParams.java
@@ -1,0 +1,41 @@
+package com.sistema.payments.application.provider;
+
+public class CreateChargeParams {
+    private final String referenceId;
+    private final long amountMinor;
+    private final String currency;
+    private final String payerName;
+    private final String payerDocument;
+
+    public CreateChargeParams(String referenceId,
+                              long amountMinor,
+                              String currency,
+                              String payerName,
+                              String payerDocument) {
+        this.referenceId = referenceId;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.payerName = payerName;
+        this.payerDocument = payerDocument;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getPayerName() {
+        return payerName;
+    }
+
+    public String getPayerDocument() {
+        return payerDocument;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/provider/CreatePayoutParams.java
+++ b/src/main/java/com/sistema/payments/application/provider/CreatePayoutParams.java
@@ -1,0 +1,41 @@
+package com.sistema.payments.application.provider;
+
+public class CreatePayoutParams {
+    private final String referenceId;
+    private final long amountMinor;
+    private final String currency;
+    private final String pixKey;
+    private final String description;
+
+    public CreatePayoutParams(String referenceId,
+                              long amountMinor,
+                              String currency,
+                              String pixKey,
+                              String description) {
+        this.referenceId = referenceId;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.pixKey = pixKey;
+        this.description = description;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getPixKey() {
+        return pixKey;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/provider/PayoutCreated.java
+++ b/src/main/java/com/sistema/payments/application/provider/PayoutCreated.java
@@ -1,0 +1,13 @@
+package com.sistema.payments.application.provider;
+
+public class PayoutCreated {
+    private final String externalPaymentId;
+
+    public PayoutCreated(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+}

--- a/src/main/java/com/sistema/payments/application/provider/PixProviderClient.java
+++ b/src/main/java/com/sistema/payments/application/provider/PixProviderClient.java
@@ -1,0 +1,7 @@
+package com.sistema.payments.application.provider;
+
+public interface PixProviderClient {
+    ChargeCreated createCharge(CreateChargeParams params);
+
+    PayoutCreated createPayout(CreatePayoutParams params);
+}

--- a/src/main/java/com/sistema/payments/domain/model/Payment.java
+++ b/src/main/java/com/sistema/payments/domain/model/Payment.java
@@ -1,0 +1,219 @@
+package com.sistema.payments.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class Payment {
+    private final UUID id;
+    private final UUID tenantId;
+    private final PaymentType type;
+    private PaymentStatus status;
+    private final long amountMinor;
+    private final String currency;
+    private final String referenceType;
+    private final String referenceId;
+    private final String idempotencyKey;
+    private String externalProvider;
+    private String externalPaymentId;
+    private String externalTxid;
+    private String qrCode;
+    private String copyPaste;
+    private Instant expiresAt;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant confirmedAt;
+    private String failureReason;
+    private UUID walletFromAccountId;
+    private UUID walletToAccountId;
+    private UUID ledgerTransactionId;
+
+    public Payment(UUID id,
+                   UUID tenantId,
+                   PaymentType type,
+                   PaymentStatus status,
+                   long amountMinor,
+                   String currency,
+                   String referenceType,
+                   String referenceId,
+                   String idempotencyKey,
+                   String externalProvider,
+                   String externalPaymentId,
+                   String externalTxid,
+                   String qrCode,
+                   String copyPaste,
+                   Instant expiresAt,
+                   Instant createdAt,
+                   Instant updatedAt,
+                   Instant confirmedAt,
+                   String failureReason,
+                   UUID walletFromAccountId,
+                   UUID walletToAccountId,
+                   UUID ledgerTransactionId) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.type = type;
+        this.status = status;
+        this.amountMinor = amountMinor;
+        this.currency = currency;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.idempotencyKey = idempotencyKey;
+        this.externalProvider = externalProvider;
+        this.externalPaymentId = externalPaymentId;
+        this.externalTxid = externalTxid;
+        this.qrCode = qrCode;
+        this.copyPaste = copyPaste;
+        this.expiresAt = expiresAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.confirmedAt = confirmedAt;
+        this.failureReason = failureReason;
+        this.walletFromAccountId = walletFromAccountId;
+        this.walletToAccountId = walletToAccountId;
+        this.ledgerTransactionId = ledgerTransactionId;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public PaymentType getType() {
+        return type;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PaymentStatus status) {
+        this.status = status;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public String getExternalProvider() {
+        return externalProvider;
+    }
+
+    public void setExternalProvider(String externalProvider) {
+        this.externalProvider = externalProvider;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getExternalTxid() {
+        return externalTxid;
+    }
+
+    public void setExternalTxid(String externalTxid) {
+        this.externalTxid = externalTxid;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public String getCopyPaste() {
+        return copyPaste;
+    }
+
+    public void setCopyPaste(String copyPaste) {
+        this.copyPaste = copyPaste;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Instant getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(Instant confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public UUID getWalletFromAccountId() {
+        return walletFromAccountId;
+    }
+
+    public void setWalletFromAccountId(UUID walletFromAccountId) {
+        this.walletFromAccountId = walletFromAccountId;
+    }
+
+    public UUID getWalletToAccountId() {
+        return walletToAccountId;
+    }
+
+    public void setWalletToAccountId(UUID walletToAccountId) {
+        this.walletToAccountId = walletToAccountId;
+    }
+
+    public UUID getLedgerTransactionId() {
+        return ledgerTransactionId;
+    }
+
+    public void setLedgerTransactionId(UUID ledgerTransactionId) {
+        this.ledgerTransactionId = ledgerTransactionId;
+    }
+}

--- a/src/main/java/com/sistema/payments/domain/model/PaymentStatus.java
+++ b/src/main/java/com/sistema/payments/domain/model/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.sistema.payments.domain.model;
+
+public enum PaymentStatus {
+    PENDING,
+    CONFIRMED,
+    FAILED,
+    CANCELED
+}

--- a/src/main/java/com/sistema/payments/domain/model/PaymentType.java
+++ b/src/main/java/com/sistema/payments/domain/model/PaymentType.java
@@ -1,0 +1,6 @@
+package com.sistema.payments.domain.model;
+
+public enum PaymentType {
+    PIX_CASHIN,
+    PIX_PAYOUT
+}

--- a/src/main/java/com/sistema/payments/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/sistema/payments/domain/repository/PaymentRepository.java
@@ -1,0 +1,20 @@
+package com.sistema.payments.domain.repository;
+
+import com.sistema.payments.domain.model.Payment;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+
+    Optional<Payment> findById(UUID tenantId, UUID paymentId);
+
+    Optional<Payment> findByIdempotencyKey(UUID tenantId, String idempotencyKey);
+
+    Optional<Payment> findByExternalPaymentId(UUID tenantId, String externalPaymentId);
+
+    Optional<Payment> findByExternalPaymentId(String externalPaymentId);
+
+    Optional<Payment> findByReference(UUID tenantId, String referenceType, String referenceId);
+}

--- a/src/main/java/com/sistema/payments/domain/repository/PaymentWebhookEventRepository.java
+++ b/src/main/java/com/sistema/payments/domain/repository/PaymentWebhookEventRepository.java
@@ -1,0 +1,8 @@
+package com.sistema.payments.domain.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface PaymentWebhookEventRepository {
+    boolean registerEvent(UUID tenantId, String externalPaymentId, String eventType, Instant receivedAt);
+}

--- a/src/main/java/com/sistema/payments/infra/entity/PaymentEntity.java
+++ b/src/main/java/com/sistema/payments/infra/entity/PaymentEntity.java
@@ -1,0 +1,255 @@
+package com.sistema.payments.infra.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payments")
+public class PaymentEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "tenant_id")
+    private UUID tenantId;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "amount_minor")
+    private long amountMinor;
+
+    @Column(name = "currency")
+    private String currency;
+
+    @Column(name = "reference_type")
+    private String referenceType;
+
+    @Column(name = "reference_id")
+    private String referenceId;
+
+    @Column(name = "idempotency_key")
+    private String idempotencyKey;
+
+    @Column(name = "external_provider")
+    private String externalProvider;
+
+    @Column(name = "external_payment_id")
+    private String externalPaymentId;
+
+    @Column(name = "external_txid")
+    private String externalTxid;
+
+    @Column(name = "qr_code")
+    private String qrCode;
+
+    @Column(name = "copy_paste")
+    private String copyPaste;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "confirmed_at")
+    private Instant confirmedAt;
+
+    @Column(name = "failure_reason")
+    private String failureReason;
+
+    @Column(name = "wallet_from_account_id")
+    private UUID walletFromAccountId;
+
+    @Column(name = "wallet_to_account_id")
+    private UUID walletToAccountId;
+
+    @Column(name = "ledger_transaction_id")
+    private UUID ledgerTransactionId;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public long getAmountMinor() {
+        return amountMinor;
+    }
+
+    public void setAmountMinor(long amountMinor) {
+        this.amountMinor = amountMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(String referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getReferenceId() {
+        return referenceId;
+    }
+
+    public void setReferenceId(String referenceId) {
+        this.referenceId = referenceId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getExternalProvider() {
+        return externalProvider;
+    }
+
+    public void setExternalProvider(String externalProvider) {
+        this.externalProvider = externalProvider;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getExternalTxid() {
+        return externalTxid;
+    }
+
+    public void setExternalTxid(String externalTxid) {
+        this.externalTxid = externalTxid;
+    }
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public void setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+    }
+
+    public String getCopyPaste() {
+        return copyPaste;
+    }
+
+    public void setCopyPaste(String copyPaste) {
+        this.copyPaste = copyPaste;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Instant getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(Instant confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public UUID getWalletFromAccountId() {
+        return walletFromAccountId;
+    }
+
+    public void setWalletFromAccountId(UUID walletFromAccountId) {
+        this.walletFromAccountId = walletFromAccountId;
+    }
+
+    public UUID getWalletToAccountId() {
+        return walletToAccountId;
+    }
+
+    public void setWalletToAccountId(UUID walletToAccountId) {
+        this.walletToAccountId = walletToAccountId;
+    }
+
+    public UUID getLedgerTransactionId() {
+        return ledgerTransactionId;
+    }
+
+    public void setLedgerTransactionId(UUID ledgerTransactionId) {
+        this.ledgerTransactionId = ledgerTransactionId;
+    }
+}

--- a/src/main/java/com/sistema/payments/infra/entity/PaymentWebhookEventEntity.java
+++ b/src/main/java/com/sistema/payments/infra/entity/PaymentWebhookEventEntity.java
@@ -1,0 +1,68 @@
+package com.sistema.payments.infra.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payment_webhook_events")
+public class PaymentWebhookEventEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "tenant_id")
+    private UUID tenantId;
+
+    @Column(name = "external_payment_id")
+    private String externalPaymentId;
+
+    @Column(name = "event_type")
+    private String eventType;
+
+    @Column(name = "received_at")
+    private Instant receivedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getExternalPaymentId() {
+        return externalPaymentId;
+    }
+
+    public void setExternalPaymentId(String externalPaymentId) {
+        this.externalPaymentId = externalPaymentId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public Instant getReceivedAt() {
+        return receivedAt;
+    }
+
+    public void setReceivedAt(Instant receivedAt) {
+        this.receivedAt = receivedAt;
+    }
+}

--- a/src/main/java/com/sistema/payments/infra/mapper/PaymentEntityMapper.java
+++ b/src/main/java/com/sistema/payments/infra/mapper/PaymentEntityMapper.java
@@ -1,0 +1,65 @@
+package com.sistema.payments.infra.mapper;
+
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.infra.entity.PaymentEntity;
+
+public final class PaymentEntityMapper {
+    private PaymentEntityMapper() {
+    }
+
+    public static PaymentEntity toEntity(Payment payment) {
+        PaymentEntity entity = new PaymentEntity();
+        entity.setId(payment.getId());
+        entity.setTenantId(payment.getTenantId());
+        entity.setType(payment.getType().name());
+        entity.setStatus(payment.getStatus().name());
+        entity.setAmountMinor(payment.getAmountMinor());
+        entity.setCurrency(payment.getCurrency());
+        entity.setReferenceType(payment.getReferenceType());
+        entity.setReferenceId(payment.getReferenceId());
+        entity.setIdempotencyKey(payment.getIdempotencyKey());
+        entity.setExternalProvider(payment.getExternalProvider());
+        entity.setExternalPaymentId(payment.getExternalPaymentId());
+        entity.setExternalTxid(payment.getExternalTxid());
+        entity.setQrCode(payment.getQrCode());
+        entity.setCopyPaste(payment.getCopyPaste());
+        entity.setExpiresAt(payment.getExpiresAt());
+        entity.setCreatedAt(payment.getCreatedAt());
+        entity.setUpdatedAt(payment.getUpdatedAt());
+        entity.setConfirmedAt(payment.getConfirmedAt());
+        entity.setFailureReason(payment.getFailureReason());
+        entity.setWalletFromAccountId(payment.getWalletFromAccountId());
+        entity.setWalletToAccountId(payment.getWalletToAccountId());
+        entity.setLedgerTransactionId(payment.getLedgerTransactionId());
+        return entity;
+    }
+
+    public static Payment toDomain(PaymentEntity entity) {
+        return new Payment(
+                entity.getId(),
+                entity.getTenantId(),
+                PaymentType.valueOf(entity.getType()),
+                PaymentStatus.valueOf(entity.getStatus()),
+                entity.getAmountMinor(),
+                entity.getCurrency(),
+                entity.getReferenceType(),
+                entity.getReferenceId(),
+                entity.getIdempotencyKey(),
+                entity.getExternalProvider(),
+                entity.getExternalPaymentId(),
+                entity.getExternalTxid(),
+                entity.getQrCode(),
+                entity.getCopyPaste(),
+                entity.getExpiresAt(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt(),
+                entity.getConfirmedAt(),
+                entity.getFailureReason(),
+                entity.getWalletFromAccountId(),
+                entity.getWalletToAccountId(),
+                entity.getLedgerTransactionId()
+        );
+    }
+}

--- a/src/main/java/com/sistema/payments/infra/provider/FakePixProviderClient.java
+++ b/src/main/java/com/sistema/payments/infra/provider/FakePixProviderClient.java
@@ -1,0 +1,31 @@
+package com.sistema.payments.infra.provider;
+
+import com.sistema.payments.application.provider.ChargeCreated;
+import com.sistema.payments.application.provider.CreateChargeParams;
+import com.sistema.payments.application.provider.CreatePayoutParams;
+import com.sistema.payments.application.provider.PayoutCreated;
+import com.sistema.payments.application.provider.PixProviderClient;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+@ApplicationScoped
+public class FakePixProviderClient implements PixProviderClient {
+    @Override
+    public ChargeCreated createCharge(CreateChargeParams params) {
+        String externalId = "pix_charge_" + UUID.randomUUID();
+        String txid = "txid_" + UUID.randomUUID();
+        String copyPaste = "000201FAKEPIX" + params.getReferenceId();
+        String qrCode = "data:image/png;base64,FAKEQR";
+        Instant expiresAt = Instant.now().plus(30, ChronoUnit.MINUTES);
+        return new ChargeCreated(externalId, txid, qrCode, copyPaste, expiresAt);
+    }
+
+    @Override
+    public PayoutCreated createPayout(CreatePayoutParams params) {
+        String externalId = "pix_payout_" + UUID.randomUUID();
+        return new PayoutCreated(externalId);
+    }
+}

--- a/src/main/java/com/sistema/payments/infra/repository/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/sistema/payments/infra/repository/PaymentRepositoryAdapter.java
@@ -1,0 +1,67 @@
+package com.sistema.payments.infra.repository;
+
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.payments.infra.entity.PaymentEntity;
+import com.sistema.payments.infra.mapper.PaymentEntityMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class PaymentRepositoryAdapter implements PaymentRepository, PanacheRepository<PaymentEntity> {
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Override
+    public Payment save(Payment payment) {
+        PaymentEntity entity = PaymentEntityMapper.toEntity(payment);
+        PaymentEntity existing = entityManager.find(PaymentEntity.class, entity.getId());
+        if (existing == null) {
+            persist(entity);
+        } else {
+            entity = entityManager.merge(entity);
+        }
+        entityManager.flush();
+        return PaymentEntityMapper.toDomain(entity);
+    }
+
+    @Override
+    public Optional<Payment> findById(UUID tenantId, UUID paymentId) {
+        PaymentEntity entity = find("tenantId = ?1 and id = ?2", tenantId, paymentId).firstResult();
+        return entity == null ? Optional.empty() : Optional.of(PaymentEntityMapper.toDomain(entity));
+    }
+
+    @Override
+    public Optional<Payment> findByIdempotencyKey(UUID tenantId, String idempotencyKey) {
+        PaymentEntity entity = find("tenantId = ?1 and idempotencyKey = ?2", tenantId, idempotencyKey).firstResult();
+        return entity == null ? Optional.empty() : Optional.of(PaymentEntityMapper.toDomain(entity));
+    }
+
+    @Override
+    public Optional<Payment> findByExternalPaymentId(UUID tenantId, String externalPaymentId) {
+        PaymentEntity entity = find("tenantId = ?1 and externalPaymentId = ?2", tenantId, externalPaymentId).firstResult();
+        return entity == null ? Optional.empty() : Optional.of(PaymentEntityMapper.toDomain(entity));
+    }
+
+    @Override
+    public Optional<Payment> findByExternalPaymentId(String externalPaymentId) {
+        PaymentEntity entity = find("externalPaymentId = ?1", externalPaymentId).firstResult();
+        return entity == null ? Optional.empty() : Optional.of(PaymentEntityMapper.toDomain(entity));
+    }
+
+    @Override
+    public Optional<Payment> findByReference(UUID tenantId, String referenceType, String referenceId) {
+        PaymentEntity entity = find(
+                "tenantId = ?1 and referenceType = ?2 and referenceId = ?3",
+                tenantId,
+                referenceType,
+                referenceId
+        ).firstResult();
+        return entity == null ? Optional.empty() : Optional.of(PaymentEntityMapper.toDomain(entity));
+    }
+}

--- a/src/main/java/com/sistema/payments/infra/repository/PaymentWebhookEventRepositoryAdapter.java
+++ b/src/main/java/com/sistema/payments/infra/repository/PaymentWebhookEventRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package com.sistema.payments.infra.repository;
+
+import com.sistema.payments.domain.repository.PaymentWebhookEventRepository;
+import com.sistema.payments.infra.entity.PaymentWebhookEventEntity;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.PersistenceException;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@ApplicationScoped
+public class PaymentWebhookEventRepositoryAdapter implements PaymentWebhookEventRepository, PanacheRepository<PaymentWebhookEventEntity> {
+    @Override
+    public boolean registerEvent(UUID tenantId, String externalPaymentId, String eventType, Instant receivedAt) {
+        PaymentWebhookEventEntity entity = new PaymentWebhookEventEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setTenantId(tenantId);
+        entity.setExternalPaymentId(externalPaymentId);
+        entity.setEventType(eventType);
+        entity.setReceivedAt(receivedAt);
+        try {
+            persist(entity);
+            getEntityManager().flush();
+            return true;
+        } catch (PersistenceException ex) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
+++ b/src/main/java/com/sistema/wallet/api/dto/CreateWalletAccountRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Pattern;
 
 public class CreateWalletAccountRequest {
     @NotBlank(message = "ownerType is required")
-    @ValidEnum(enumClass = WalletOwnerType.class, message = "ownerType must be one of: CUSTOMER, FUNDING")
+    @ValidEnum(enumClass = WalletOwnerType.class, message = "ownerType must be one of: CUSTOMER, FUNDING, INTERNAL")
     private String ownerType;
 
     @NotBlank(message = "ownerId is required")

--- a/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
+++ b/src/main/java/com/sistema/wallet/domain/model/WalletOwnerType.java
@@ -2,5 +2,6 @@ package com.sistema.wallet.domain.model;
 
 public enum WalletOwnerType {
     CUSTOMER,
-    FUNDING
+    FUNDING,
+    INTERNAL
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=
 quarkus.datasource.username=sa
 quarkus.datasource.password=
 wallet.api-keys=key-dev=00000000-0000-0000-0000-000000000000
+payments.provider=FAKE
+payments.webhook.secret=change-me

--- a/src/main/resources/db/migration/V5__payments.sql
+++ b/src/main/resources/db/migration/V5__payments.sql
@@ -1,0 +1,48 @@
+create table if not exists payments (
+    id uuid primary key,
+    tenant_id uuid not null,
+    type varchar(32) not null,
+    status varchar(32) not null,
+    amount_minor bigint not null,
+    currency varchar(16) not null,
+    reference_type varchar(64) not null,
+    reference_id varchar(128) not null,
+    idempotency_key varchar(128) not null,
+    external_provider varchar(64),
+    external_payment_id varchar(128),
+    external_txid varchar(128),
+    qr_code varchar(2048),
+    copy_paste varchar(2048),
+    expires_at timestamp,
+    created_at timestamp not null,
+    updated_at timestamp not null,
+    confirmed_at timestamp,
+    failure_reason varchar(255),
+    wallet_from_account_id uuid,
+    wallet_to_account_id uuid,
+    ledger_transaction_id uuid,
+    constraint fk_payments_tenant
+        foreign key (tenant_id) references tenants (id)
+);
+
+create unique index if not exists uq_payments_tenant_idempotency
+    on payments (tenant_id, idempotency_key);
+
+create index if not exists idx_payments_reference
+    on payments (tenant_id, reference_type, reference_id);
+
+create index if not exists idx_payments_external_id
+    on payments (tenant_id, external_payment_id);
+
+create table if not exists payment_webhook_events (
+    id uuid primary key,
+    tenant_id uuid not null,
+    external_payment_id varchar(128) not null,
+    event_type varchar(64) not null,
+    received_at timestamp not null,
+    constraint fk_payment_webhook_events_tenant
+        foreign key (tenant_id) references tenants (id)
+);
+
+create unique index if not exists uq_payment_webhook_event
+    on payment_webhook_events (tenant_id, external_payment_id, event_type);

--- a/src/test/java/com/sistema/payments/application/CreatePixChargeUseCaseTest.java
+++ b/src/test/java/com/sistema/payments/application/CreatePixChargeUseCaseTest.java
@@ -1,0 +1,155 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.command.CreatePixChargeCommand;
+import com.sistema.payments.application.model.PixChargeResult;
+import com.sistema.payments.application.provider.ChargeCreated;
+import com.sistema.payments.application.provider.PixProviderClient;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CreatePixChargeUseCaseTest {
+
+    @Test
+    void shouldCreateChargeAndPersistExternalData() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        PixProviderClient pixProviderClient = Mockito.mock(PixProviderClient.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID creditWalletId = UUID.randomUUID();
+        UUID cashWalletId = UUID.randomUUID();
+        WalletAccount creditWallet = walletAccount(creditWalletId, tenantId, "BRL", WalletOwnerType.CUSTOMER);
+        WalletAccount cashWallet = walletAccount(cashWalletId, tenantId, "BRL", WalletOwnerType.FUNDING);
+
+        when(paymentRepository.findByIdempotencyKey(tenantId, "idemp-1")).thenReturn(Optional.empty());
+        when(walletAccountRepository.findById(tenantId, creditWalletId)).thenReturn(Optional.of(creditWallet));
+        when(walletAccountsService.getOrCreateCashAtPsp(tenantId, "BRL")).thenReturn(cashWallet);
+        when(pixProviderClient.createCharge(any())).thenReturn(
+                new ChargeCreated("ext-1", "txid-1", "qr", "copy", Instant.now().plusSeconds(60))
+        );
+        when(paymentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CreatePixChargeUseCase useCase = new CreatePixChargeUseCase(
+                paymentRepository,
+                walletAccountRepository,
+                walletAccountsService,
+                pixProviderClient,
+                "FAKE"
+        );
+
+        PixChargeResult result = useCase.execute(tenantId, new CreatePixChargeCommand(
+                "ORDER",
+                "ref-1",
+                1200,
+                "BRL",
+                "Joao",
+                "123",
+                creditWalletId.toString(),
+                "idemp-1"
+        ));
+
+        assertEquals("PENDING", result.getStatus());
+        assertEquals("ext-1", result.getExternalPaymentId());
+        assertEquals("txid-1", result.getTxid());
+        assertNotNull(result.getQrCode());
+        assertNotNull(result.getCopyPaste());
+        assertNotNull(result.getExpiresAt());
+        verify(pixProviderClient).createCharge(any());
+    }
+
+    @Test
+    void shouldReturnExistingOnIdempotency() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        PixProviderClient pixProviderClient = Mockito.mock(PixProviderClient.class);
+
+        UUID tenantId = UUID.randomUUID();
+        Payment existing = new Payment(
+                UUID.randomUUID(),
+                tenantId,
+                PaymentType.PIX_CASHIN,
+                PaymentStatus.PENDING,
+                1200,
+                "BRL",
+                "ORDER",
+                "ref-1",
+                "idemp-1",
+                "FAKE",
+                "ext-1",
+                "txid-1",
+                "qr",
+                "copy",
+                Instant.now().plusSeconds(60),
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null
+        );
+        when(paymentRepository.findByIdempotencyKey(tenantId, "idemp-1")).thenReturn(Optional.of(existing));
+
+        CreatePixChargeUseCase useCase = new CreatePixChargeUseCase(
+                paymentRepository,
+                walletAccountRepository,
+                walletAccountsService,
+                pixProviderClient,
+                "FAKE"
+        );
+
+        PixChargeResult result = useCase.execute(tenantId, new CreatePixChargeCommand(
+                "ORDER",
+                "ref-1",
+                1200,
+                "BRL",
+                "Joao",
+                "123",
+                UUID.randomUUID().toString(),
+                "idemp-1"
+        ));
+
+        assertEquals(existing.getId(), result.getPaymentId());
+        assertEquals(existing.getExternalPaymentId(), result.getExternalPaymentId());
+        assertEquals(existing.getExternalTxid(), result.getTxid());
+        assertEquals(existing.getQrCode(), result.getQrCode());
+        assertEquals(existing.getCopyPaste(), result.getCopyPaste());
+        assertEquals(existing.getExpiresAt(), result.getExpiresAt());
+        verify(pixProviderClient, Mockito.never()).createCharge(any());
+    }
+
+    private WalletAccount walletAccount(UUID id, UUID tenantId, String currency, WalletOwnerType ownerType) {
+        return new WalletAccount(
+                id,
+                tenantId,
+                ownerType,
+                "owner",
+                currency,
+                WalletAccountStatus.ACTIVE,
+                null,
+                UUID.randomUUID(),
+                Instant.now()
+        );
+    }
+}

--- a/src/test/java/com/sistema/payments/application/CreatePixPayoutUseCaseTest.java
+++ b/src/test/java/com/sistema/payments/application/CreatePixPayoutUseCaseTest.java
@@ -1,0 +1,139 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.command.CreatePixPayoutCommand;
+import com.sistema.payments.application.exception.PaymentsInsufficientBalanceException;
+import com.sistema.payments.application.model.PixPayoutResult;
+import com.sistema.payments.application.provider.PayoutCreated;
+import com.sistema.payments.application.provider.PixProviderClient;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.application.exception.WalletInsufficientBalanceException;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import com.sistema.wallet.domain.repository.WalletAccountRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CreatePixPayoutUseCaseTest {
+
+    @Test
+    void shouldReserveAndCreatePayout() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        TransferBetweenWalletAccountsUseCase transferUseCase = Mockito.mock(TransferBetweenWalletAccountsUseCase.class);
+        PixProviderClient pixProviderClient = Mockito.mock(PixProviderClient.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID debitWalletId = UUID.randomUUID();
+        UUID clearingWalletId = UUID.randomUUID();
+        WalletAccount debitWallet = walletAccount(debitWalletId, tenantId, "BRL", WalletOwnerType.CUSTOMER);
+        WalletAccount clearingWallet = walletAccount(clearingWalletId, tenantId, "BRL", WalletOwnerType.INTERNAL);
+
+        when(paymentRepository.findByIdempotencyKey(tenantId, "idemp-1")).thenReturn(Optional.empty());
+        when(walletAccountRepository.findById(tenantId, debitWalletId)).thenReturn(Optional.of(debitWallet));
+        when(walletAccountsService.getOrCreateOutboundClearing(tenantId, "BRL")).thenReturn(clearingWallet);
+        when(paymentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(pixProviderClient.createPayout(any())).thenReturn(new PayoutCreated("ext-payout"));
+
+        CreatePixPayoutUseCase useCase = new CreatePixPayoutUseCase(
+                paymentRepository,
+                walletAccountRepository,
+                walletAccountsService,
+                transferUseCase,
+                pixProviderClient,
+                "FAKE"
+        );
+
+        PixPayoutResult result = useCase.execute(tenantId, new CreatePixPayoutCommand(
+                "SETTLEMENT",
+                "ref-1",
+                5000,
+                "BRL",
+                "pix-key",
+                debitWalletId.toString(),
+                "Payout",
+                "idemp-1"
+        ));
+
+        assertEquals("PENDING", result.getStatus());
+        assertEquals("ext-payout", result.getExternalPaymentId());
+
+        ArgumentCaptor<TransferBetweenWalletAccountsCommand> transferCaptor =
+                ArgumentCaptor.forClass(TransferBetweenWalletAccountsCommand.class);
+        verify(transferUseCase).execute(eq(tenantId), transferCaptor.capture());
+        TransferBetweenWalletAccountsCommand transfer = transferCaptor.getValue();
+        assertEquals(debitWalletId, transfer.getFromAccountId());
+        assertEquals(clearingWalletId, transfer.getToAccountId());
+        assertEquals(5000, transfer.getAmountMinor());
+    }
+
+    @Test
+    void shouldRejectInsufficientBalance() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        WalletAccountRepository walletAccountRepository = Mockito.mock(WalletAccountRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        TransferBetweenWalletAccountsUseCase transferUseCase = Mockito.mock(TransferBetweenWalletAccountsUseCase.class);
+        PixProviderClient pixProviderClient = Mockito.mock(PixProviderClient.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID debitWalletId = UUID.randomUUID();
+        WalletAccount debitWallet = walletAccount(debitWalletId, tenantId, "BRL", WalletOwnerType.CUSTOMER);
+        WalletAccount clearingWallet = walletAccount(UUID.randomUUID(), tenantId, "BRL", WalletOwnerType.INTERNAL);
+
+        when(paymentRepository.findByIdempotencyKey(tenantId, "idemp-2")).thenReturn(Optional.empty());
+        when(walletAccountRepository.findById(tenantId, debitWalletId)).thenReturn(Optional.of(debitWallet));
+        when(walletAccountsService.getOrCreateOutboundClearing(tenantId, "BRL")).thenReturn(clearingWallet);
+        when(paymentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(transferUseCase.execute(eq(tenantId), any()))
+                .thenThrow(new WalletInsufficientBalanceException("insufficient balance"));
+
+        CreatePixPayoutUseCase useCase = new CreatePixPayoutUseCase(
+                paymentRepository,
+                walletAccountRepository,
+                walletAccountsService,
+                transferUseCase,
+                pixProviderClient,
+                "FAKE"
+        );
+
+        assertThrows(PaymentsInsufficientBalanceException.class, () -> useCase.execute(tenantId, new CreatePixPayoutCommand(
+                "SETTLEMENT",
+                "ref-2",
+                5000,
+                "BRL",
+                "pix-key",
+                debitWalletId.toString(),
+                "Payout",
+                "idemp-2"
+        )));
+    }
+
+    private WalletAccount walletAccount(UUID id, UUID tenantId, String currency, WalletOwnerType ownerType) {
+        return new WalletAccount(
+                id,
+                tenantId,
+                ownerType,
+                "owner",
+                currency,
+                WalletAccountStatus.ACTIVE,
+                null,
+                UUID.randomUUID(),
+                Instant.now()
+        );
+    }
+}

--- a/src/test/java/com/sistema/payments/application/ProcessPspWebhookUseCaseTest.java
+++ b/src/test/java/com/sistema/payments/application/ProcessPspWebhookUseCaseTest.java
@@ -1,0 +1,169 @@
+package com.sistema.payments.application;
+
+import com.sistema.payments.application.model.PspWebhookEvent;
+import com.sistema.payments.domain.model.Payment;
+import com.sistema.payments.domain.model.PaymentStatus;
+import com.sistema.payments.domain.model.PaymentType;
+import com.sistema.payments.domain.repository.PaymentRepository;
+import com.sistema.payments.domain.repository.PaymentWebhookEventRepository;
+import com.sistema.wallet.application.TransferBetweenWalletAccountsUseCase;
+import com.sistema.wallet.application.command.TransferBetweenWalletAccountsCommand;
+import com.sistema.wallet.domain.model.WalletAccount;
+import com.sistema.wallet.domain.model.WalletAccountStatus;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProcessPspWebhookUseCaseTest {
+
+    @Test
+    void shouldConfirmCashInAndTransfer() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        PaymentWebhookEventRepository webhookEventRepository = Mockito.mock(PaymentWebhookEventRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        TransferBetweenWalletAccountsUseCase transferUseCase = Mockito.mock(TransferBetweenWalletAccountsUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        UUID cashWalletId = UUID.randomUUID();
+        UUID creditWalletId = UUID.randomUUID();
+        Payment payment = new Payment(
+                paymentId,
+                tenantId,
+                PaymentType.PIX_CASHIN,
+                PaymentStatus.PENDING,
+                1000,
+                "BRL",
+                "ORDER",
+                "ref-1",
+                "idemp-1",
+                "FAKE",
+                "ext-1",
+                "txid-1",
+                "qr",
+                "copy",
+                Instant.now().plusSeconds(60),
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                cashWalletId,
+                creditWalletId,
+                null
+        );
+        when(paymentRepository.findByExternalPaymentId("ext-1")).thenReturn(Optional.of(payment));
+        when(webhookEventRepository.registerEvent(eq(tenantId), eq("ext-1"), any(), any())).thenReturn(true);
+        when(paymentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(walletAccountsService.getOrCreateCashAtPsp(tenantId, "BRL"))
+                .thenReturn(walletAccount(cashWalletId, tenantId, WalletOwnerType.FUNDING));
+
+        ProcessPspWebhookUseCase useCase = new ProcessPspWebhookUseCase(
+                paymentRepository,
+                webhookEventRepository,
+                walletAccountsService,
+                transferUseCase
+        );
+
+        PspWebhookEvent event = new PspWebhookEvent();
+        event.setExternalPaymentId("ext-1");
+        event.setStatus("CONFIRMED");
+        event.setEventType("CONFIRMED");
+
+        useCase.execute(event);
+
+        ArgumentCaptor<TransferBetweenWalletAccountsCommand> transferCaptor =
+                ArgumentCaptor.forClass(TransferBetweenWalletAccountsCommand.class);
+        verify(transferUseCase).execute(eq(tenantId), transferCaptor.capture());
+        TransferBetweenWalletAccountsCommand command = transferCaptor.getValue();
+        assertEquals(cashWalletId, command.getFromAccountId());
+        assertEquals(creditWalletId, command.getToAccountId());
+        assertEquals("pay_" + paymentId + "_confirm", command.getIdempotencyKey());
+    }
+
+    @Test
+    void shouldRollbackPayoutOnFailed() {
+        PaymentRepository paymentRepository = Mockito.mock(PaymentRepository.class);
+        PaymentWebhookEventRepository webhookEventRepository = Mockito.mock(PaymentWebhookEventRepository.class);
+        PaymentsWalletAccountsService walletAccountsService = Mockito.mock(PaymentsWalletAccountsService.class);
+        TransferBetweenWalletAccountsUseCase transferUseCase = Mockito.mock(TransferBetweenWalletAccountsUseCase.class);
+
+        UUID tenantId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        UUID debitWalletId = UUID.randomUUID();
+        UUID clearingWalletId = UUID.randomUUID();
+        Payment payment = new Payment(
+                paymentId,
+                tenantId,
+                PaymentType.PIX_PAYOUT,
+                PaymentStatus.PENDING,
+                1000,
+                "BRL",
+                "SETTLEMENT",
+                "ref-2",
+                "idemp-2",
+                "FAKE",
+                "ext-2",
+                "txid-2",
+                null,
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                debitWalletId,
+                clearingWalletId,
+                null
+        );
+        when(paymentRepository.findByExternalPaymentId("ext-2")).thenReturn(Optional.of(payment));
+        when(webhookEventRepository.registerEvent(eq(tenantId), eq("ext-2"), any(), any())).thenReturn(true);
+        when(paymentRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProcessPspWebhookUseCase useCase = new ProcessPspWebhookUseCase(
+                paymentRepository,
+                webhookEventRepository,
+                walletAccountsService,
+                transferUseCase
+        );
+
+        PspWebhookEvent event = new PspWebhookEvent();
+        event.setExternalPaymentId("ext-2");
+        event.setStatus("FAILED");
+        event.setEventType("FAILED");
+
+        useCase.execute(event);
+
+        ArgumentCaptor<TransferBetweenWalletAccountsCommand> transferCaptor =
+                ArgumentCaptor.forClass(TransferBetweenWalletAccountsCommand.class);
+        verify(transferUseCase).execute(eq(tenantId), transferCaptor.capture());
+        TransferBetweenWalletAccountsCommand command = transferCaptor.getValue();
+        assertEquals(clearingWalletId, command.getFromAccountId());
+        assertEquals(debitWalletId, command.getToAccountId());
+        assertEquals("pay_" + paymentId + "_rollback", command.getIdempotencyKey());
+    }
+
+    private WalletAccount walletAccount(UUID id, UUID tenantId, WalletOwnerType ownerType) {
+        return new WalletAccount(
+                id,
+                tenantId,
+                ownerType,
+                "owner",
+                "BRL",
+                WalletAccountStatus.ACTIVE,
+                null,
+                UUID.randomUUID(),
+                Instant.now()
+        );
+    }
+}

--- a/src/test/java/com/sistema/payments/infra/PaymentsIntegrationTest.java
+++ b/src/test/java/com/sistema/payments/infra/PaymentsIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.sistema.payments.infra;
+
+import com.sistema.infraestrutura.repositorio.DbCleanIT;
+import com.sistema.ledger.application.CreateAccountUseCase;
+import com.sistema.ledger.application.PostLedgerTransactionUseCase;
+import com.sistema.ledger.application.command.CreateAccountCommand;
+import com.sistema.ledger.application.command.PostLedgerTransactionCommand;
+import com.sistema.ledger.application.command.PostingEntryCommand;
+import com.sistema.ledger.domain.model.AccountType;
+import com.sistema.ledger.domain.model.EntryDirection;
+import com.sistema.payments.application.CreatePixChargeUseCase;
+import com.sistema.payments.application.CreatePixPayoutUseCase;
+import com.sistema.payments.application.ProcessPspWebhookUseCase;
+import com.sistema.payments.application.command.CreatePixChargeCommand;
+import com.sistema.payments.application.command.CreatePixPayoutCommand;
+import com.sistema.payments.application.model.PixChargeResult;
+import com.sistema.payments.application.model.PixPayoutResult;
+import com.sistema.payments.application.model.PspWebhookEvent;
+import com.sistema.wallet.application.CreateWalletAccountUseCase;
+import com.sistema.wallet.application.GetWalletBalanceUseCase;
+import com.sistema.wallet.application.command.CreateWalletAccountCommand;
+import com.sistema.wallet.domain.model.WalletOwnerType;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class PaymentsIntegrationTest extends DbCleanIT {
+    private static final UUID DEFAULT_TENANT = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+    @jakarta.inject.Inject
+    CreateWalletAccountUseCase createWalletAccountUseCase;
+
+    @jakarta.inject.Inject
+    GetWalletBalanceUseCase getWalletBalanceUseCase;
+
+    @jakarta.inject.Inject
+    CreatePixChargeUseCase createPixChargeUseCase;
+
+    @jakarta.inject.Inject
+    CreatePixPayoutUseCase createPixPayoutUseCase;
+
+    @jakarta.inject.Inject
+    ProcessPspWebhookUseCase processPspWebhookUseCase;
+
+    @jakarta.inject.Inject
+    CreateAccountUseCase createAccountUseCase;
+
+    @jakarta.inject.Inject
+    PostLedgerTransactionUseCase postLedgerTransactionUseCase;
+
+    @Tag("integration-test")
+    @Test
+    void shouldCreateChargeAndConfirmCashIn() {
+        var wallet = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-1", "BRL", "Wallet")
+        );
+
+        PixChargeResult result = createPixChargeUseCase.execute(
+                DEFAULT_TENANT,
+                new CreatePixChargeCommand(
+                        "ORDER",
+                        "order-1",
+                        1200,
+                        "BRL",
+                        "Joao",
+                        "123",
+                        wallet.getId().toString(),
+                        "idemp-charge-1"
+                )
+        );
+
+        PspWebhookEvent event = new PspWebhookEvent();
+        event.setExternalPaymentId(result.getExternalPaymentId());
+        event.setStatus("CONFIRMED");
+        event.setEventType("CONFIRMED");
+
+        processPspWebhookUseCase.execute(event);
+
+        var balance = getWalletBalanceUseCase.execute(DEFAULT_TENANT, wallet.getId());
+        assertEquals(1200L, balance.getBalanceMinor());
+    }
+
+    @Tag("integration-test")
+    @Test
+    void shouldRollbackPayoutOnFailed() {
+        var wallet = createWalletAccountUseCase.execute(
+                DEFAULT_TENANT,
+                new CreateWalletAccountCommand(WalletOwnerType.CUSTOMER, "user-2", "BRL", "Wallet")
+        );
+
+        fundWallet(wallet.getLedgerAccountId(), 10000);
+
+        PixPayoutResult payout = createPixPayoutUseCase.execute(
+                DEFAULT_TENANT,
+                new CreatePixPayoutCommand(
+                        "SETTLEMENT",
+                        "settlement-1",
+                        4000,
+                        "BRL",
+                        "pix-key",
+                        wallet.getId().toString(),
+                        "Payout",
+                        "idemp-payout-1"
+                )
+        );
+
+        var balanceAfterReserve = getWalletBalanceUseCase.execute(DEFAULT_TENANT, wallet.getId());
+        assertEquals(6000L, balanceAfterReserve.getBalanceMinor());
+
+        PspWebhookEvent event = new PspWebhookEvent();
+        event.setExternalPaymentId(payout.getExternalPaymentId());
+        event.setStatus("FAILED");
+        event.setEventType("FAILED");
+
+        processPspWebhookUseCase.execute(event);
+
+        var balanceAfterRollback = getWalletBalanceUseCase.execute(DEFAULT_TENANT, wallet.getId());
+        assertEquals(10000L, balanceAfterRollback.getBalanceMinor());
+    }
+
+    private void fundWallet(UUID ledgerAccountId, long amountMinor) {
+        var funding = createAccountUseCase.execute(
+                new CreateAccountCommand(DEFAULT_TENANT, "Funding", AccountType.ASSET, "BRL", true)
+        );
+
+        postLedgerTransactionUseCase.execute(new PostLedgerTransactionCommand(
+                DEFAULT_TENANT,
+                "fund-" + ledgerAccountId,
+                "fund-" + ledgerAccountId,
+                "Funding wallet",
+                Instant.now(),
+                java.util.List.of(
+                        new PostingEntryCommand(funding.getId(), EntryDirection.DEBIT, amountMinor, "BRL"),
+                        new PostingEntryCommand(ledgerAccountId, EntryDirection.CREDIT, amountMinor, "BRL")
+                )
+        ));
+    }
+}


### PR DESCRIPTION
Summary:

Implemented a Pix Payments module on top of Wallet + Ledger, including charge/payout flows, webhook processing, and provider abstraction with a fake client for tests.

Changes:

- Added Payments domain/application/API/infra layers with new endpoints and DTOs.

- Added HMAC webhook validation and event dedup persistence.

- Added migrations for payments and payment_webhook_events.

- Added unit and integration tests for Payments flows.

- Extended wallet owner types to include INTERNAL and added payments config defaults.